### PR TITLE
Fix side comments in quotes

### DIFF
--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
@@ -55,16 +55,17 @@ public class YamlCommentParser extends YamlCommentReader {
             int lastSpace = 0;
             char[] chars = this.currentLine.toCharArray();
             for (int i = 0; i < chars.length; i++) {
+                char lastC = i > 0 ? chars[i - 1] : ' ';
                 char c = chars[i];
                 if (c == ' ') {
                     lastSpace = i;
                 }
                 if (this.inQuote) {
-                    if (c == '\'' || c == '\"') {
+                    if ((c == '\'' && lastC != '\'' && lastC != '\'') || (c == '\"' && lastC != '\"')) {
                         this.inQuote = false;
                     }
                 } else {
-                    if (c == '\'' || c == '\"') {
+                    if ((c == '\'' && lastC != '\'' && lastC != '\'') || (c == '\"' && lastC != '\"')) {
                         this.inQuote = true;
                     } else if (c == '#') {
                         node.setSideComment(this.currentLine.substring(lastSpace));

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
@@ -67,7 +67,7 @@ public class YamlCommentParser extends YamlCommentReader {
                     if (c == '\'' || c == '\"') {
                         this.inQuote = true;
                     } else if (c == '#') {
-                        node.setSideComment(this.currentComment.substring(lastSpace));
+                        node.setSideComment(this.currentLine.substring(lastSpace));
                         break;
                     }
                 }

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 
 public class YamlCommentParser extends YamlCommentReader {
 
-    private static final Pattern SIDE_COMMENT_REGEX = Pattern.compile("^[ \\t]*[^#\\s].*?([ \\t]*#.*)");
+    private static final Pattern SIDE_COMMENT_REGEX = Pattern.compile("^[ \\t]*(?:.*(?:'|\\\").*?([ \\t]*#[^'\\\"]*)$|[^'\\\"]*?([ \\t]*#.*))");
 
     private StringBuilder currentComment; // block comment
 
@@ -54,7 +54,7 @@ public class YamlCommentParser extends YamlCommentReader {
         if (this.currentLine != null) {
             final Matcher sideCommentMatcher = YamlCommentParser.SIDE_COMMENT_REGEX.matcher(this.currentLine);
             if (sideCommentMatcher.matches()) {
-                node.setSideComment(sideCommentMatcher.group(1));
+                node.setSideComment(sideCommentMatcher.group(1) == null ? sideCommentMatcher.group(2) : sideCommentMatcher.group(1));
             }
         }
     }


### PR DESCRIPTION
This PR fixes the side comment parser from matching '#' signs inside of single and double quotes.

Fixes #42 