### PR TITLE
Comment fixes + Header & Comment Formatter

### DIFF
--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/ConfigurationWrapper.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/ConfigurationWrapper.java
@@ -1,0 +1,204 @@
+package org.simpleyaml.configuration;
+
+import org.simpleyaml.utils.Validate;
+
+import java.util.Objects;
+
+public class ConfigurationWrapper<T extends Configuration> {
+
+    protected final T configuration;
+    protected final String path;
+    protected final ConfigurationWrapper<T> parent;
+
+    protected ConfigurationWrapper(final T configuration, final String path, final ConfigurationWrapper<T> parent) {
+        Validate.notNull(configuration, "configuration cannot be null!");
+        this.configuration = configuration;
+        this.path = parent == null ? path : parent.childPath(path);
+        this.parent = parent;
+    }
+
+    public ConfigurationWrapper(final T configuration, final String path) {
+        this(configuration, path, null);
+    }
+
+    /**
+     * Get a wrapper builder for the given child path.
+     * @param path child path of this section path, not null.
+     * @throws IllegalArgumentException if path is null
+     * @return the child path wrapper
+     */
+    public ConfigurationWrapper<T> path(final String path) {
+        return new ConfigurationWrapper<>(configuration, path, this);
+    }
+
+    /**
+     * Set the given value to this path.
+     * <p>
+     * If value is null, the entry will be removed. Any existing entry will be
+     * replaced, regardless of what the new value is.
+     *
+     * @param value new value to set the path to.
+     * @return this object, for chaining.
+     */
+    public ConfigurationWrapper<T> set(final Object value) {
+        return set(configuration::set, value);
+    }
+
+    /**
+     * Set the given value to the provided child path.
+     * <p>
+     * If value is null, the entry will be removed. Any existing entry will be
+     * replaced, regardless of what the new value is.
+     *
+     * @param path the child path of this section path.
+     * @param value new value to set the child path to.
+     * @return this object, for chaining.
+     */
+    public ConfigurationWrapper<T> set(final String path, final Object value) {
+        return setToChild(configuration::set, path, value);
+    }
+
+    /**
+     * Sets the default value of this path.
+     * <p>
+     * If no source {@link Configuration} was provided as a default
+     * collection, then a new {@link MemoryConfiguration} will be created to
+     * hold the new default value.
+     * <p>
+     * If value is null, the value will be removed from the default
+     * Configuration source.
+     * <p>
+     * If the value as returned by {@link ConfigurationSection#getDefaultSection()} is null, then
+     * this will create a new section at the path, replacing anything that may
+     * have existed there previously.
+     *
+     * @param value value to set the default to.
+     * @return this object, for chaining.
+     */
+    public ConfigurationWrapper<T> addDefault(final Object value) {
+        return set(configuration::addDefault, value);
+    }
+
+    /**
+     * Sets the default value of the provided child path.
+     * <p>
+     * If no source {@link Configuration} was provided as a default
+     * collection, then a new {@link MemoryConfiguration} will be created to
+     * hold the new default value.
+     * <p>
+     * If value is null, the value will be removed from the default
+     * Configuration source.
+     * <p>
+     * If the value as returned by {@link ConfigurationSection#getDefaultSection()} is null, then
+     * this will create a new section at the path, replacing anything that may
+     * have existed there previously.
+     *
+     * @param path the child path of this section path.
+     * @param value value to set the default to.
+     * @return this object, for chaining.
+     */
+    public ConfigurationWrapper<T> addDefault(final String path, final Object value) {
+        return setToChild(configuration::addDefault, path, value);
+    }
+
+    /**
+     * Creates an empty {@link ConfigurationSection} at this path.
+     * <p>
+     * Any value that was previously set at this path will be overwritten. If
+     * the previous value was itself a {@link ConfigurationSection}, it will
+     * be orphaned.
+     *
+     * @return this object, for chaining.
+     */
+    public ConfigurationWrapper<T> createSection() {
+        return apply(configuration::createSection);
+    }
+
+    /**
+     * Creates an empty {@link ConfigurationSection} at the provided child path.
+     * <p>
+     * Any value that was previously set at this path will be overwritten. If
+     * the previous value was itself a {@link ConfigurationSection}, it will
+     * be orphaned.
+     *
+     * @param path the child path of this section path.
+     * @return this object, for chaining.
+     */
+    public ConfigurationWrapper<T> createSection(final String path) {
+        return applyToChild(configuration::createSection, path);
+    }
+
+    /**
+     * Gets the current path.
+     * @return this path.
+     */
+    public String getCurrentPath() {
+        return this.path;
+    }
+
+    /**
+     * Returns to the parent.
+     * @return the parent path wrapper, or null if this path does not have a parent.
+     */
+    public ConfigurationWrapper<T> parent() {
+        if (this.parent == null && this.path != null) {
+            int lastSectionIndex = this.path.lastIndexOf(this.configuration.options().pathSeparator());
+
+            if (lastSectionIndex >= 0) {
+                return new ConfigurationWrapper<>(this.configuration, this.path.substring(0, lastSectionIndex));
+            }
+        }
+        return this.parent;
+    }
+
+    protected final String childPath(final String path) {
+        if (this.path == null) {
+            return path;
+        }
+        return this.path + this.configuration.options().pathSeparator() + path;
+    }
+
+    protected ConfigurationWrapper<T> apply(final ApplyToPath method) {
+        method.apply(this.path);
+        return this;
+    }
+
+    protected ConfigurationWrapper<T> applyToChild(final ApplyToPath method, final String path) {
+        method.apply(this.childPath(path));
+        return this;
+    }
+
+    protected ConfigurationWrapper<T> set(final SetToPath method, final Object value) {
+        method.set(this.path, value);
+        return this;
+    }
+
+    protected ConfigurationWrapper<T> setToChild(final SetToPath method, final String path, final Object value) {
+        method.set(this.childPath(path), value);
+        return this;
+    }
+
+    @FunctionalInterface
+    protected interface ApplyToPath {
+        void apply(final String path);
+    }
+
+    @FunctionalInterface
+    protected interface SetToPath {
+        <T> void set(final String path, final T value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConfigurationWrapper<?> that = (ConfigurationWrapper<?>) o;
+        return configuration == that.configuration && Objects.equals(path, that.path) && Objects.equals(parent, that.parent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(configuration, path, parent);
+    }
+
+}

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/MemorySection.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/MemorySection.java
@@ -104,14 +104,12 @@ public class MemorySection implements ConfigurationSection {
         final char separator = root.options().pathSeparator();
 
         final StringBuilder builder = new StringBuilder();
-        if (section != null) {
-            for (ConfigurationSection parent = section; parent != null && parent != relativeTo; parent = parent.getParent()) {
-                if (builder.length() > 0) {
-                    builder.insert(0, separator);
-                }
-
-                builder.insert(0, parent.getName());
+        for (ConfigurationSection parent = section; parent != null && parent != relativeTo; parent = parent.getParent()) {
+            if (builder.length() > 0) {
+                builder.insert(0, separator);
             }
+
+            builder.insert(0, parent.getName());
         }
 
         if (key != null && key.length() > 0) {
@@ -252,8 +250,6 @@ public class MemorySection implements ConfigurationSection {
 
     @Override
     public void set(final String path, final Object value) {
-        Validate.notEmpty(path, "Cannot set to an empty path");
-
         final Configuration root = this.getRoot();
         if (root == null) {
             throw new IllegalStateException("Cannot use section without a root");

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/CommentFormatter.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/CommentFormatter.java
@@ -1,0 +1,108 @@
+package org.simpleyaml.configuration.comments;
+
+import org.simpleyaml.utils.StringUtils;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Converts a comment between a raw-format meant to be read by computers
+ * to a human-format meant to be read by humans and vice versa.
+ */
+public interface CommentFormatter {
+
+    /**
+     * Parse the comment from a string that may contain a raw-formatted comment (for instance from a configuration file)
+     * to a human-friendly contentful representation of that comment.
+     *
+     * @param raw the comment to parse that may contain special format characters with leading and trailing space
+     * @param type the comment type
+     * @param node the comment node
+     * @return the comment in the expected format to be read by humans
+     */
+    String parse(String raw, CommentType type, KeyTree.Node node);
+
+    /**
+     * Given a comment returns the raw-formatted string to be dumped somewhere like a file.
+     *
+     * @param comment the comment to be dumped
+     * @param type the comment type
+     * @param node the comment node
+     * @return the raw-formatted comment string to be dumped, for instance to a configuration file
+     */
+    String dump(String comment, CommentType type, KeyTree.Node node);
+
+    default String parse(String raw, CommentType type) {
+        return parse(raw, type, null);
+    }
+
+    default String parse(String raw) {
+        return parse(raw, CommentType.BLOCK);
+    }
+
+    default String dump(String comment, CommentType type) {
+        return dump(comment, type, null);
+    }
+
+    default String dump(String comment) {
+        return dump(comment, CommentType.BLOCK);
+    }
+
+    static String format(int indent,
+                         String prefixFirst, String prefixMultiline,
+                         String comment,
+                         CommentType type,
+                         String suffixMultiline, String suffixLast) {
+
+        if (comment == null) {
+            return "";
+        }
+
+        Stream<String> stream = Arrays.stream(StringUtils.lines(comment));
+
+        final String indentation = StringUtils.indentation(indent);
+
+        String delimiter = "\n" + indentation;
+
+        if (suffixMultiline != null) {
+            delimiter = suffixMultiline + delimiter;
+        }
+
+        if (prefixFirst == null) {
+            prefixFirst = "";
+        }
+
+        if (prefixMultiline == null) {
+            prefixMultiline = prefixFirst;
+        }
+
+        if (type == CommentType.BLOCK) {
+            prefixFirst = indentation + prefixFirst;
+        }
+
+        delimiter += prefixMultiline;
+
+        if (suffixLast == null) {
+            suffixLast = "";
+        }
+
+        return stream.collect(Collectors.joining(delimiter, prefixFirst, suffixLast));
+    }
+
+    static String format(String prefixFirst, String prefixMultiline,
+                         String comment,
+                         String suffixMultiline, String suffixLast) {
+        return format(0, prefixFirst, prefixMultiline, comment, CommentType.BLOCK, suffixMultiline, suffixLast);
+    }
+
+    static String format(int indent, String comment, CommentType type, CommentFormatterConfiguration configuration) {
+        return format(
+                indent,
+                configuration.prefixFirst(), configuration.prefixMultiline(),
+                comment,
+                type,
+                configuration.suffixMultiline(), configuration.suffixLast()
+        );
+    }
+}

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/CommentFormatterConfiguration.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/CommentFormatterConfiguration.java
@@ -1,0 +1,77 @@
+package org.simpleyaml.configuration.comments;
+
+import java.util.Objects;
+
+public class CommentFormatterConfiguration {
+
+    private String prefixFirst, prefixMultiline, suffixMultiline, suffixLast;
+
+    public CommentFormatterConfiguration prefix(String prefix) {
+        return prefix(prefix, prefix);
+    }
+
+    public CommentFormatterConfiguration prefix(String prefixFirst, String prefixMultiline) {
+        this.prefixFirst = prefixFirst;
+        this.prefixMultiline = prefixMultiline;
+        return this;
+    }
+
+    public CommentFormatterConfiguration suffix(String suffixLast) {
+        this.suffixLast = suffixLast;
+        return this;
+    }
+
+    public CommentFormatterConfiguration suffix(String suffixLast, String suffixMultiline) {
+        this.suffixLast = suffixLast;
+        this.suffixMultiline = suffixMultiline;
+        return this;
+    }
+
+    public String prefixFirst(String defaultPrefix) {
+        return prefixFirst != null ? prefixFirst : defaultPrefix;
+    }
+
+    public String prefixFirst() {
+        return prefixFirst("");
+    }
+
+    public String prefixMultiline(String defaultPrefix) {
+        return prefixMultiline != null ? prefixMultiline : prefixFirst(defaultPrefix);
+    }
+
+    public String prefixMultiline() {
+        return prefixMultiline("");
+    }
+
+    public String suffixMultiline(String defaultSuffix) {
+        return suffixMultiline != null ? suffixMultiline : defaultSuffix;
+    }
+
+    public String suffixMultiline() {
+        return suffixMultiline("");
+    }
+
+    public String suffixLast(String defaultSuffix) {
+        return suffixLast != null ? suffixLast : defaultSuffix;
+    }
+
+    public String suffixLast() {
+        return suffixLast("");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CommentFormatterConfiguration that = (CommentFormatterConfiguration) o;
+        return Objects.equals(prefixFirst, that.prefixFirst)
+                && Objects.equals(prefixMultiline, that.prefixMultiline)
+                && Objects.equals(suffixMultiline, that.suffixMultiline)
+                && Objects.equals(suffixLast, that.suffixLast);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(prefixFirst, prefixMultiline, suffixMultiline, suffixLast);
+    }
+}

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/CommentFormatterConfiguration.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/CommentFormatterConfiguration.java
@@ -1,5 +1,7 @@
 package org.simpleyaml.configuration.comments;
 
+import org.simpleyaml.utils.StringUtils;
+
 import java.util.Objects;
 
 public class CommentFormatterConfiguration {
@@ -73,5 +75,15 @@ public class CommentFormatterConfiguration {
     @Override
     public int hashCode() {
         return Objects.hash(prefixFirst, prefixMultiline, suffixMultiline, suffixLast);
+    }
+
+    @Override
+    public String toString() {
+        return StringUtils.quoteNewLines("{" +
+                "prefixFirst='" + prefixFirst + '\'' +
+                ", prefixMultiline='" + prefixMultiline + '\'' +
+                ", suffixMultiline='" + suffixMultiline + '\'' +
+                ", suffixLast='" + suffixLast + '\'' +
+                '}');
     }
 }

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/Commentable.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/Commentable.java
@@ -3,22 +3,22 @@ package org.simpleyaml.configuration.comments;
 public interface Commentable {
 
     /**
-     * Adds a comment to the section or value selected by path.
+     * Set a comment to the section or value selected by path.
      * Comment will be indented automatically.
      * Multi-line comments can be provided using \n character.
      *
-     * @param path    path of desired section or value
+     * @param path    path of desired section or key
      * @param comment the comment to add, # symbol is not needed
-     * @param type    either above (block) or side
+     * @param type    either above (BLOCK) or SIDE
      */
     void setComment(String path, String comment, CommentType type);
 
     /**
-     * Adds a block comment above the section or value selected by path.
+     * Set a block comment above the section or value selected by path.
      * Comment will be indented automatically.
      * Multi-line comments can be provided using \n character.
      *
-     * @param path    path of desired section or value
+     * @param path    path of desired section or key
      * @param comment the comment to add, # symbol is not needed
      */
     default void setComment(final String path, final String comment) {
@@ -28,8 +28,8 @@ public interface Commentable {
     /**
      * Retrieve the comment of the section or value selected by path.
      *
-     * @param path path of desired section or value
-     * @param type either above (block) or side
+     * @param path path of desired section or key
+     * @param type either above (BLOCK) or SIDE
      * @return the comment of the section or value selected by path,
      * or null if that path does not have any comment of this type
      */
@@ -38,7 +38,7 @@ public interface Commentable {
     /**
      * Retrieve the block comment of the section or value selected by path.
      *
-     * @param path path of desired section or value
+     * @param path path of desired section or key
      * @return the block comment of the section or value selected by path,
      * or null if that path does not have any comment of type block
      */

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/KeyTree.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/KeyTree.java
@@ -1,11 +1,9 @@
 package org.simpleyaml.configuration.comments;
 
 import org.simpleyaml.configuration.ConfigurationOptions;
+import org.simpleyaml.utils.Validate;
 
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class KeyTree {
 
@@ -16,6 +14,7 @@ public class KeyTree {
     private final ConfigurationOptions options;
 
     public KeyTree(final ConfigurationOptions options) {
+        Validate.notNull(options);
         this.options = options;
     }
 
@@ -124,6 +123,28 @@ public class KeyTree {
 
         public void setSideComment(final String sideComment) {
             this.sideComment = sideComment;
+        }
+
+        public KeyTree.Node getParent() {
+            return this.parent;
+        }
+
+        public boolean isRootNode() {
+            return this.parent == null;
+        }
+
+        public boolean isFirstNode() {
+            if (!this.isRootNode() && this.parent.isRootNode()) {
+                KeyTree.Node first = this.parent.children.getFirst();
+                if (first.getName() == null && this.parent.children.size() > 1) { // footer
+                    first = this.parent.children.get(1);
+                }
+                if (first == this) {
+                    final Iterator<String> keys = KeyTree.this.options.configuration().getKeys(false).iterator();
+                    return !keys.hasNext() || keys.next().equals(first.getName());
+                }
+            }
+            return false;
         }
 
         public int getIndentation() {

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/KeyTree.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/comments/KeyTree.java
@@ -23,7 +23,7 @@ public class KeyTree {
         KeyTree.Node parent = this.root;
         String key = path;
         if (path != null) {
-            final int i = path.lastIndexOf('.');
+            final int i = path.lastIndexOf(this.options.pathSeparator());
             if (i >= 0) {
                 final String parentPath = path.substring(0, i);
                 key = path.substring(i + 1);
@@ -62,6 +62,10 @@ public class KeyTree {
 
     public Set<Map.Entry<String, KeyTree.Node>> entries() {
         return this.nodes.entrySet();
+    }
+
+    public ConfigurationOptions options() {
+        return this.options;
     }
 
     @Override

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/file/FileConfiguration.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/file/FileConfiguration.java
@@ -2,6 +2,7 @@ package org.simpleyaml.configuration.file;
 
 import org.simpleyaml.configuration.Configuration;
 import org.simpleyaml.configuration.MemoryConfiguration;
+import org.simpleyaml.configuration.comments.CommentFormatter;
 import org.simpleyaml.exceptions.InvalidConfigurationException;
 import org.simpleyaml.utils.Validate;
 
@@ -11,6 +12,7 @@ import java.io.*;
  * This is a base class for all File based implementations of {@link Configuration}
  *
  * @author Bukkit
+ * @author Carleslc (modified buildHeader)
  * @see <a href="https://github.com/Bukkit/Bukkit/tree/master/src/main/java/org/bukkit/configuration/file/FileConfiguration.java">Bukkit Source</a>
  */
 public abstract class FileConfiguration extends MemoryConfiguration {
@@ -222,11 +224,39 @@ public abstract class FileConfiguration extends MemoryConfiguration {
     /**
      * Compiles the header for this {@link FileConfiguration} and returns the
      * result.
+     * <p>
+     * This will use the header from {@link #options()} {@link FileConfigurationOptions#header()},
+     * respecting the rules of {@link FileConfigurationOptions#copyHeader()}
+     * and {@link FileConfigurationOptions#headerFormatter()} if set.
      *
      * @return Compiled header
      */
-    protected String buildHeader() {
-        return "";
+    public String buildHeader() {
+        final FileConfigurationOptions options = this.options();
+
+        if (!options.copyHeader()) {
+            return "";
+        }
+
+        final Configuration def = this.getDefaults();
+
+        if (def instanceof FileConfiguration) {
+            final FileConfiguration defaults = (FileConfiguration) def;
+            final String defaultsHeader = defaults.buildHeader();
+
+            if (defaultsHeader != null && !defaultsHeader.isEmpty()) {
+                return defaultsHeader;
+            }
+        }
+
+        final String header = options.header();
+        final CommentFormatter headerFormatter = options.headerFormatter();
+
+        if (headerFormatter != null) {
+            return headerFormatter.dump(header);
+        }
+
+        return header != null ? header + '\n' : "";
     }
 
 }

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/file/FileConfiguration.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/file/FileConfiguration.java
@@ -253,10 +253,11 @@ public abstract class FileConfiguration extends MemoryConfiguration {
         final CommentFormatter headerFormatter = options.headerFormatter();
 
         if (headerFormatter != null) {
-            return headerFormatter.dump(header);
+            final String headerDump = headerFormatter.dump(header);
+            return headerDump != null ? headerDump : "";
         }
 
-        return header != null ? header + '\n' : "";
+        return header != null && !header.isEmpty() ? header + '\n' : "";
     }
 
 }

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/file/FileConfigurationOptions.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/file/FileConfigurationOptions.java
@@ -3,6 +3,7 @@ package org.simpleyaml.configuration.file;
 import org.simpleyaml.configuration.Configuration;
 import org.simpleyaml.configuration.MemoryConfiguration;
 import org.simpleyaml.configuration.MemoryConfigurationOptions;
+import org.simpleyaml.configuration.comments.CommentFormatter;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -12,7 +13,7 @@ import java.util.Objects;
  * Various settings for controlling the input and output of a {@link FileConfiguration}
  *
  * @author Bukkit
- * @author Carlos Lazaro Costa (added charset option)
+ * @author Carlos Lazaro Costa
  * @see <a href="https://github.com/Bukkit/Bukkit/tree/master/src/main/java/org/bukkit/configuration/file/FileConfigurationOptions.java">Bukkit Source</a>
  */
 public class FileConfigurationOptions extends MemoryConfigurationOptions {
@@ -20,8 +21,8 @@ public class FileConfigurationOptions extends MemoryConfigurationOptions {
     private Charset charset = StandardCharsets.UTF_8;
 
     private String header = null;
-
     private boolean copyHeader = true;
+    private CommentFormatter headerFormatter;
 
     protected FileConfigurationOptions(final MemoryConfiguration configuration) {
         super(configuration);
@@ -60,11 +61,7 @@ public class FileConfigurationOptions extends MemoryConfigurationOptions {
     /**
      * Gets the header that will be applied to the top of the saved output.
      * <p>
-     * This header will be commented out and applied directly at the top of
-     * the generated output of the {@link FileConfiguration}. It is not
-     * required to include a newline at the end of the header as it will
-     * automatically be applied, but you may include one if you wish for extra
-     * spacing.
+     * This header will be commented out.
      * <p>
      * Null is a valid value which will indicate that no header is to be
      * applied. The default value is null.
@@ -84,14 +81,13 @@ public class FileConfigurationOptions extends MemoryConfigurationOptions {
      * automatically be applied, but you may include one if you wish for extra
      * spacing.
      * <p>
-     * Null is a valid value which will indicate that no header is to be
-     * applied.
+     * Null is a valid header which will indicate that no header is to be applied.
      *
-     * @param value New header
+     * @param header New header
      * @return This object, for chaining
      */
-    public FileConfigurationOptions header(final String value) {
-        this.header = value;
+    public FileConfigurationOptions header(final String header) {
+        this.header = header;
         return this;
     }
 
@@ -141,6 +137,26 @@ public class FileConfigurationOptions extends MemoryConfigurationOptions {
         return this;
     }
 
+    /**
+     * Gets the header format used for parsing and dumping the header.
+     *
+     * @return The header formatter
+     */
+    public CommentFormatter headerFormatter() {
+        return this.headerFormatter;
+    }
+
+    /**
+     * Sets the header format used for parsing and dumping the header.
+     *
+     * @param headerFormatter The header formatter
+     * @return This object, for chaining
+     */
+    public FileConfigurationOptions headerFormatter(final CommentFormatter headerFormatter) {
+        this.headerFormatter = headerFormatter;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -149,11 +165,12 @@ public class FileConfigurationOptions extends MemoryConfigurationOptions {
         FileConfigurationOptions that = (FileConfigurationOptions) o;
         return copyHeader == that.copyHeader &&
                 Objects.equals(charset, that.charset) &&
-                Objects.equals(header, that.header);
+                Objects.equals(header, that.header) &&
+                Objects.equals(headerFormatter, that.headerFormatter);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), charset, header, copyHeader);
+        return Objects.hash(super.hashCode(), charset, header, copyHeader, headerFormatter);
     }
 }

--- a/Simple-Configuration/src/main/java/org/simpleyaml/exceptions/InvalidConfigurationException.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/exceptions/InvalidConfigurationException.java
@@ -2,6 +2,8 @@ package org.simpleyaml.exceptions;
 
 import org.simpleyaml.configuration.Configuration;
 
+import java.io.IOException;
+
 /**
  * Exception thrown when attempting to load an invalid {@link Configuration}
  *
@@ -9,7 +11,7 @@ import org.simpleyaml.configuration.Configuration;
  * @see <a href="https://github.com/Bukkit/Bukkit/tree/master/src/main/java/org/bukkit/configuration/InvalidConfigurationException.java">Bukkit Source</a>
  */
 @SuppressWarnings("serial")
-public class InvalidConfigurationException extends Exception {
+public class InvalidConfigurationException extends IOException {
 
     /**
      * Creates a new instance of InvalidConfigurationException without a

--- a/Simple-Configuration/src/main/java/org/simpleyaml/utils/StringUtils.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/utils/StringUtils.java
@@ -1,0 +1,72 @@
+package org.simpleyaml.utils;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+public final class StringUtils {
+
+    public static final String BLANK_LINE = "\n\n";
+
+    private static final Pattern NEW_LINE = Pattern.compile("\r?\n");
+    private static final Pattern INDENTATION = Pattern.compile("^[^\\S\n]+", Pattern.MULTILINE); // all leading whitespace except new line
+
+    public static String[] lines(final String content) {
+        return NEW_LINE.split(content);
+    }
+
+    public static String indentation(final int n) {
+        return padding(n, ' ');
+    }
+
+    public static String padding(final int n, final char pad) {
+        if (n <= 0) {
+            return "";
+        }
+        char[] padding = new char[n];
+        for (int i = 0; i < n; i++) {
+            padding[i] = pad;
+        }
+        return new String(padding);
+    }
+
+    public static String stripIndentation(String s) {
+        if (s == null) {
+            return null;
+        }
+        return INDENTATION.matcher(s).replaceAll("");
+    }
+
+    public static String stripPrefix(String s, String prefix) {
+        return stripPrefix(s, prefix, null);
+    }
+
+    public static String stripPrefix(String s, String prefix, String defaultPrefix) {
+        if (s == null) {
+            return null;
+        }
+        int skip = 0;
+        if (prefix != null && s.startsWith(prefix)) {
+            skip = prefix.length();
+        } else if (defaultPrefix != null && s.startsWith(defaultPrefix)) {
+            skip = defaultPrefix.length();
+        }
+        return s.substring(skip);
+    }
+
+    public static String afterNewLine(String s) {
+        if (s == null) {
+            return null;
+        }
+        int nl = s.indexOf('\n');
+        return nl >= 0 ? s.substring(nl + 1) : "";
+    }
+
+    public static boolean allLinesArePrefixed(final String comment, final String prefix) {
+        return Arrays.stream(lines(comment)).allMatch(line -> line.trim().startsWith(prefix));
+    }
+
+    public static boolean allLinesArePrefixedOrBlank(final String comment, final String prefix) {
+        return Arrays.stream(lines(comment)).map(String::trim).allMatch(line -> line.isEmpty() || line.startsWith(prefix));
+    }
+
+}

--- a/Simple-Configuration/src/main/java/org/simpleyaml/utils/StringUtils.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/utils/StringUtils.java
@@ -7,11 +7,15 @@ public final class StringUtils {
 
     public static final String BLANK_LINE = "\n\n";
 
-    private static final Pattern NEW_LINE = Pattern.compile("\r?\n");
+    private static final Pattern NEW_LINE = Pattern.compile("\\R"); // like "\r?\n" but also with other unicode line separators
     private static final Pattern INDENTATION = Pattern.compile("^[^\\S\n]+", Pattern.MULTILINE); // all leading whitespace except new line
 
+    public static String[] lines(final String content, boolean stripTrailingNewLines) {
+        return NEW_LINE.split(content, stripTrailingNewLines ? 0 : -1);
+    }
+
     public static String[] lines(final String content) {
-        return NEW_LINE.split(content);
+        return lines(content, true);
     }
 
     public static String indentation(final int n) {
@@ -61,8 +65,22 @@ public final class StringUtils {
         return nl >= 0 ? s.substring(nl + 1) : "";
     }
 
+    public static String[] splitTrailingNewLines(String s) {
+        if (s == null) {
+            return null;
+        }
+        final String[] parts = new String[2];
+        int i = s.length() - 1;
+        while (i >= 0 && s.charAt(i) == '\n') {
+            i--;
+        }
+        parts[0] = i >= 0 ? s.substring(0, i + 1) : "";
+        parts[1] = s.substring(i + 1);
+        return parts;
+    }
+
     public static boolean allLinesArePrefixed(final String comment, final String prefix) {
-        return Arrays.stream(lines(comment)).allMatch(line -> line.trim().startsWith(prefix));
+        return Arrays.stream(lines(comment, false)).allMatch(line -> line.trim().startsWith(prefix));
     }
 
     public static boolean allLinesArePrefixedOrBlank(final String comment, final String prefix) {
@@ -70,7 +88,7 @@ public final class StringUtils {
     }
 
     public static String quoteNewLines(String s) {
-        return NEW_LINE.matcher(s).replaceAll("\\n");
+        return NEW_LINE.matcher(s).replaceAll("\\\\n");
     }
 
 }

--- a/Simple-Configuration/src/main/java/org/simpleyaml/utils/StringUtils.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/utils/StringUtils.java
@@ -69,4 +69,8 @@ public final class StringUtils {
         return Arrays.stream(lines(comment)).map(String::trim).allMatch(line -> line.isEmpty() || line.startsWith(prefix));
     }
 
+    public static String quoteNewLines(String s) {
+        return NEW_LINE.matcher(s).replaceAll("\\n");
+    }
+
 }

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/BlankLineYamlCommentFormatter.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/BlankLineYamlCommentFormatter.java
@@ -1,0 +1,30 @@
+package org.simpleyaml.configuration.comments;
+
+import org.simpleyaml.utils.StringUtils;
+
+/**
+ * {@link YamlCommentFormat#BLANK_LINE} formatter
+ */
+public class BlankLineYamlCommentFormatter extends YamlCommentFormatter {
+
+    public BlankLineYamlCommentFormatter() {
+        super();
+        this.stripPrefix(true).trim(false);
+        blockFormatter.prefix('\n' + blockFormatter.prefixFirst(), blockFormatter.prefixMultiline());
+    }
+
+    @Override
+    public String dump(String comment, CommentType type, KeyTree.Node node) {
+        if (type == CommentType.SIDE) {
+            final String defaultPrefixFirst = sideFormatter.prefixFirst();
+            int indentation = node == null ? 0 : node.getIndentation();
+            final String blankLineSideFirstPrefix = '\n' + StringUtils.indentation(indentation) + StringUtils.stripIndentation(defaultPrefixFirst);
+            sideFormatter.prefix(blankLineSideFirstPrefix, sideFormatter.prefixMultiline());
+            final String dump = super.dump(comment, type, node);
+            sideFormatter.prefix(defaultPrefixFirst, sideFormatter.prefixMultiline());
+            return dump;
+        }
+        return super.dump(comment, type, node);
+    }
+
+}

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/PrettyYamlCommentFormatter.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/PrettyYamlCommentFormatter.java
@@ -1,0 +1,33 @@
+package org.simpleyaml.configuration.comments;
+
+/**
+ * {@link YamlCommentFormat#PRETTY} formatter
+ */
+public class PrettyYamlCommentFormatter extends YamlCommentFormatter {
+
+    public PrettyYamlCommentFormatter() {
+        super();
+        this.stripPrefix(true).trim(true);
+    }
+
+    @Override
+    public String dump(String comment, CommentType type, KeyTree.Node node) {
+        if (type == CommentType.BLOCK && node != null && node.getIndentation() == 0 && !node.isFirstNode()) { // Block comment for root keys except the first key
+            final YamlCommentFormatterConfiguration blockCommentFormatterConfiguration = this.formatterConfiguration(CommentType.BLOCK);
+            final String defaultPrefixFirst = blockCommentFormatterConfiguration.prefixFirst();
+            final String defaultPrefixMultiline = blockCommentFormatterConfiguration.prefixMultiline();
+
+            // Prepend default first prefix with a blank line
+            blockCommentFormatterConfiguration.prefix('\n' + defaultPrefixFirst, defaultPrefixMultiline);
+
+            final String dump = super.dump(comment, type, node);
+
+            // Reset first prefix to default
+            blockCommentFormatterConfiguration.prefix(defaultPrefixFirst, defaultPrefixMultiline);
+
+            return dump;
+        }
+        return super.dump(comment, type, node);
+    }
+
+}

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentFormat.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentFormat.java
@@ -1,0 +1,89 @@
+package org.simpleyaml.configuration.comments;
+
+public enum YamlCommentFormat {
+
+    /**
+     * DEFAULT comment format gets comments in a readable way stripping the # comment prefix,
+     * without leading and trailing spaces or blank lines and without indentation.
+     * <p></p>
+     * The prefix for setting new comments is:
+     * <p>  - BLOCK comments: "# ", i.e. a # followed by a space.
+     * <p>  - SIDE comments: " # ", i.e. a space followed by # with a space.
+     * <p></p>
+     * If when setting a comment all lines are blank or already prefixed with a comment prefix # then it does not add additional formatting.
+     */
+    DEFAULT (YamlCommentFormatter::new),
+
+    /**
+     * PRETTY comment format gets comments in a readable way stripping the # comment prefix,
+     * without leading and trailing spaces or blank lines and without indentation.
+     * <p></p>
+     * The prefix for setting new comments is:
+     * <p>  - BLOCK comments with 0 indentation (root keys) except first key: "\n# ", i.e. a blank line followed by # with a space.
+     *        Multiline comments do not add additional blank lines.
+     * <p>  - BLOCK comments with some indentation (child keys) or first key: "# ", i.e. a # followed by a space.
+     * <p>  - SIDE comments: " # ", i.e. a space followed by # with a space.
+     * <p></p>
+     * If when setting a comment all lines are blank or already prefixed with a comment prefix # then it does not add additional formatting.
+     */
+    PRETTY (PrettyYamlCommentFormatter::new),
+
+    /**
+     * BLANK_LINE comment format gets comments in a readable way stripping the # comment prefix and without indentation,
+     * but it keeps trailing spaces and blank lines.
+     * <p></p>
+     * The prefix for setting new comments is:
+     * <p>  - BLOCK comments: "\n# ", i.e. a blank line followed by # with a space.
+     *        Multiline comments do not add additional blank lines.
+     * <p>  - SIDE comments: "\n# ", i.e. a new line followed by # with a space.
+     *        This will add the comment below.
+     * <p></p>
+     * If when setting a comment all lines are blank or already prefixed with a comment prefix # then it does not add additional formatting.
+     */
+    BLANK_LINE (BlankLineYamlCommentFormatter::new),
+
+    /**
+     * RAW comment format gets comments as they are in the file configuration,
+     * with blank lines and the comment prefix with # character,
+     * but without the indentation prefix.
+     * <p></p>
+     * The prefix for setting new comments is:
+     * <p>  - BLOCK comments: "# ", i.e. a # followed by a space.
+     * <p>  - SIDE comments: " # ", i.e. a space followed by # with a space.
+     * <p></p>
+     * If when setting a comment all lines are blank or already prefixed with a comment prefix # then it does not add additional formatting.
+     */
+    RAW (() -> new YamlCommentFormatter().stripPrefix(false).trim(false));
+
+    private YamlCommentFormatter yamlCommentFormatter;
+    private final YamlCommentFormatterFactory yamlCommentFormatterFactory;
+
+    YamlCommentFormat(final YamlCommentFormatterFactory yamlCommentFormatterFactory) {
+        this.yamlCommentFormatterFactory = yamlCommentFormatterFactory;
+    }
+
+    public YamlCommentFormatter commentFormatter() {
+        if (this.yamlCommentFormatter == null) {
+            this.buildCommentFormatter();
+        }
+        return this.yamlCommentFormatter;
+    }
+
+    private void buildCommentFormatter() {
+        this.yamlCommentFormatter = this.yamlCommentFormatterFactory.commentFormatter();
+    }
+
+    public static void reset() {
+        // Rebuild formatters to reset any changes
+        for (YamlCommentFormat format : values()) {
+            if (format.yamlCommentFormatter != null) {
+                format.buildCommentFormatter();
+            }
+        }
+    }
+
+    @FunctionalInterface
+    public interface YamlCommentFormatterFactory {
+        YamlCommentFormatter commentFormatter();
+    }
+}

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentFormatter.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentFormatter.java
@@ -1,0 +1,129 @@
+package org.simpleyaml.configuration.comments;
+
+import org.simpleyaml.utils.StringUtils;
+
+import java.util.Objects;
+
+public class YamlCommentFormatter implements CommentFormatter {
+
+    private final YamlCommentFormatterConfiguration blockFormatter;
+    private final YamlSideCommentFormatterConfiguration sideFormatter;
+
+    public YamlCommentFormatter(YamlCommentFormatterConfiguration blockFormatter, YamlSideCommentFormatterConfiguration sideFormatter) {
+        this.blockFormatter = blockFormatter;
+        this.sideFormatter = sideFormatter;
+    }
+
+    public YamlCommentFormatter(YamlCommentFormatterConfiguration blockFormatter) {
+        this(blockFormatter, new YamlSideCommentFormatterConfiguration());
+        this.stripPrefix(true);
+    }
+
+    public YamlCommentFormatter() {
+        this(new YamlCommentFormatterConfiguration());
+    }
+
+    @Override
+    public String parse(String raw, CommentType type, KeyTree.Node node) {
+        YamlCommentFormatterConfiguration formatterConfiguration = formatterConfiguration(type);
+
+        String prefixFirst = StringUtils.stripIndentation(formatterConfiguration.prefixFirst());
+        String prefixMultiline = StringUtils.stripIndentation(formatterConfiguration.prefixMultiline());
+
+        StringBuilder commentBuilder = new StringBuilder();
+
+        String[] lines = StringUtils.lines(raw);
+
+        boolean strip = formatterConfiguration.stripPrefix();
+
+        if (lines.length > 0) {
+            commentBuilder.append(parseCommentLine(lines[0], prefixFirst, strip));
+        }
+
+        for (int i = 1; i < lines.length; i++) {
+            commentBuilder.append('\n').append(parseCommentLine(lines[i], prefixMultiline, strip));
+        }
+
+        final String comment = commentBuilder.toString();
+
+        return formatterConfiguration.trim() ? comment.trim() : comment;
+    }
+
+    protected String parseCommentLine(String line, String prefix, boolean strip) {
+        String commentLine = StringUtils.stripIndentation(line);
+        if (strip) {
+            commentLine = StringUtils.stripPrefix(commentLine, prefix, YamlCommentFormatterConfiguration.COMMENT_INDICATOR);
+        }
+        return commentLine;
+    }
+
+    @Override
+    public String dump(String comment, CommentType type, KeyTree.Node node) {
+        final YamlCommentFormatterConfiguration formatterConfiguration = this.formatterConfiguration(type);
+
+        String prefix = null;
+        String prefixMultiline = null;
+        int indentation = node.getIndentation();
+
+        if (comment != null) {
+            if (StringUtils.allLinesArePrefixedOrBlank(comment, YamlCommentFormatterConfiguration.COMMENT_INDICATOR)) {
+                if (type == CommentType.SIDE && !comment.startsWith(" ")) {
+                    prefix = " ";
+                    prefixMultiline = "";
+                }
+            } else {
+                prefix = formatterConfiguration.prefixFirst();
+                prefixMultiline = formatterConfiguration.prefixMultiline();
+            }
+        }
+
+        return CommentFormatter.format(indentation, prefix, prefixMultiline, comment, type, formatterConfiguration.suffixMultiline(), formatterConfiguration.suffixLast());
+    }
+
+    public YamlCommentFormatterConfiguration formatterConfiguration(CommentType type) {
+        return type == CommentType.BLOCK ? this.blockFormatter : this.sideFormatter;
+    }
+
+    /**
+     * Set if stripping the prefix is desired.
+     * <p></p>
+     * If strip is true then the comment prefix will be stripped away.
+     * <p></p>
+     * Default is true.
+     * @param strip if stripping the prefix is desired
+     * @return this object, for chaining
+     */
+    public YamlCommentFormatter stripPrefix(final boolean strip) {
+        this.blockFormatter.stripPrefix(strip);
+        this.sideFormatter.stripPrefix(strip);
+        return this;
+    }
+
+    /**
+     * Set if leading and trailing spaces and blank lines at the beginning and end of the comments should be stripped away.
+     * <p>
+     * This does not affect to every line of a multiline comment. Only to the beginning and end of the whole comment.
+     * <p></p>
+     * Default is true.
+     * @param trim if {@link String#trim} should be applied to comments
+     * @return this object, for chaining
+     */
+    public YamlCommentFormatter trim(final boolean trim) {
+        this.blockFormatter.trim(trim);
+        this.sideFormatter.trim(trim);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        YamlCommentFormatter that = (YamlCommentFormatter) o;
+        return Objects.equals(blockFormatter, that.blockFormatter) && Objects.equals(sideFormatter, that.sideFormatter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(blockFormatter, sideFormatter);
+    }
+}

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentFormatterConfiguration.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentFormatterConfiguration.java
@@ -1,0 +1,98 @@
+package org.simpleyaml.configuration.comments;
+
+import org.simpleyaml.utils.StringUtils;
+import org.simpleyaml.utils.Validate;
+
+import java.util.Objects;
+
+public class YamlCommentFormatterConfiguration extends CommentFormatterConfiguration {
+
+    public static final String COMMENT_INDICATOR = "#";
+    public static final String DEFAULT_COMMENT_PREFIX = COMMENT_INDICATOR + " ";
+
+    private boolean stripPrefix = false;
+    private boolean trim = true;
+
+    public YamlCommentFormatterConfiguration() {
+        this(DEFAULT_COMMENT_PREFIX);
+    }
+
+    public YamlCommentFormatterConfiguration(String prefix) {
+        this.prefix(prefix);
+    }
+
+    public YamlCommentFormatterConfiguration(String prefix, String prefixMultiline) {
+        this.prefix(prefix, prefixMultiline);
+    }
+
+    @Override
+    public YamlCommentFormatterConfiguration prefix(String prefix) {
+        checkCommentPrefix(prefix);
+        super.prefix(prefix, prefix);
+        return this;
+    }
+
+    @Override
+    public YamlCommentFormatterConfiguration prefix(String prefixFirst, String prefixMultiline) {
+        checkCommentPrefix(prefixFirst);
+        checkCommentPrefixMultiline(prefixMultiline);
+        super.prefix(prefixFirst, prefixMultiline);
+        return this;
+    }
+
+    @Override
+    public YamlCommentFormatterConfiguration suffix(String suffixLast) {
+        checkCommentPrefix(StringUtils.afterNewLine(suffixLast));
+        super.suffix(suffixLast);
+        return this;
+    }
+
+    @Override
+    public YamlCommentFormatterConfiguration suffix(String suffixLast, String suffixMultiline) {
+        checkCommentPrefix(StringUtils.afterNewLine(suffixLast));
+        checkCommentPrefixMultiline(StringUtils.afterNewLine(suffixMultiline));
+        super.suffix(suffixLast, suffixMultiline);
+        return this;
+    }
+
+    public YamlCommentFormatterConfiguration stripPrefix(boolean stripPrefix) {
+        this.stripPrefix = stripPrefix;
+        return this;
+    }
+
+    public boolean stripPrefix() {
+        return this.stripPrefix;
+    }
+
+    public YamlCommentFormatterConfiguration trim(boolean trim) {
+        this.trim = trim;
+        return this;
+    }
+
+    public boolean trim() {
+        return this.trim;
+    }
+
+    public void checkCommentPrefix(final String commentPrefix) {
+        Validate.isTrue(commentPrefix != null && StringUtils.allLinesArePrefixedOrBlank(commentPrefix, COMMENT_INDICATOR),
+                "All comment prefix lines must be blank or optional space followed by a " + COMMENT_INDICATOR);
+    }
+
+    public void checkCommentPrefixMultiline(final String commentPrefix) {
+        checkCommentPrefix(commentPrefix);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        YamlCommentFormatterConfiguration that = (YamlCommentFormatterConfiguration) o;
+        return stripPrefix == that.stripPrefix && trim == that.trim;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), stripPrefix, trim);
+    }
+}

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentFormatterConfiguration.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentFormatterConfiguration.java
@@ -95,4 +95,13 @@ public class YamlCommentFormatterConfiguration extends CommentFormatterConfigura
     public int hashCode() {
         return Objects.hash(super.hashCode(), stripPrefix, trim);
     }
+
+    @Override
+    public String toString() {
+        return "{" +
+                "stripPrefix=" + stripPrefix +
+                ", trim=" + trim +
+                ", " + super.toString() +
+                '}';
+    }
 }

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 public class YamlCommentParser extends YamlCommentReader {
 
+    // TODO: https://github.com/Carleslc/Simple-YAML/issues/42
     private static final Pattern SIDE_COMMENT_REGEX = Pattern.compile("^[ \\t]*[^#\\s].*?([ \\t]*#.*)");
 
     private StringBuilder currentComment; // block comment

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
@@ -4,15 +4,13 @@ import org.simpleyaml.configuration.file.YamlConfigurationOptions;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class YamlCommentParser extends YamlCommentReader {
 
-    // TODO: https://github.com/Carleslc/Simple-YAML/issues/42
-    private static final Pattern SIDE_COMMENT_REGEX = Pattern.compile("^[ \\t]*[^#\\s].*?([ \\t]*#.*)");
-
-    private StringBuilder currentComment; // block comment
+    private StringBuilder blockComment;
+    private boolean blockCommentStarted = false;
+    private boolean headerParsed = false;
 
     public YamlCommentParser(final YamlConfigurationOptions options, final Reader reader) {
         super(options, reader);
@@ -20,44 +18,86 @@ public class YamlCommentParser extends YamlCommentReader {
 
     public void parse() throws IOException {
         while (this.nextLine()) {
-            if (this.isBlank() || this.isComment()) {
+            if (this.isBlank()) {
                 this.appendLine();
+            } else if (this.isComment()) {
+                this.appendCommentLine();
             } else {
-                this.trackComment();
+                this.track();
             }
         }
 
-        // Last comment
-        this.trackComment();
-
-        this.reader.close();
+        // Footer
+        this.track();
     }
 
     private void appendLine() {
-        if (this.currentComment == null) {
-            this.currentComment = new StringBuilder(this.currentLine);
+        if (this.blockComment == null) {
+            this.blockComment = new StringBuilder();
+        }
+        this.blockComment.append('\n');
+    }
+
+    private void appendCommentLine() {
+        if (this.blockComment == null) {
+            this.blockComment = new StringBuilder(this.currentLine);
         } else {
-            this.currentComment.append(this.currentLine);
+            if (this.blockCommentStarted) {
+                // multiline comment
+                this.blockComment.append('\n');
+            }
+            this.blockComment.append(this.currentLine);
         }
-        this.currentComment.append('\n');
+        this.blockCommentStarted = true;
     }
 
-    private void trackComment() {
-        final KeyTree.Node node = this.track();
-        if (this.currentComment != null) {
-            node.setComment(this.currentComment.toString());
-            this.currentComment = null;
-        }
-        this.setSideComment(node);
+    @Override
+    protected KeyTree.Node track() throws IOException {
+        final KeyTree.Node node = super.track();
+        this.trackBlockComment(node);
+        this.trackSideComment(node);
+        return node;
     }
 
-    private void setSideComment(final KeyTree.Node node) {
-        if (this.currentLine != null) {
-            final Matcher sideCommentMatcher = YamlCommentParser.SIDE_COMMENT_REGEX.matcher(this.currentLine);
-            if (sideCommentMatcher.matches()) {
-                node.setSideComment(sideCommentMatcher.group(1));
+    private void trackBlockComment(final KeyTree.Node node) {
+        if (node != null && this.blockComment != null) {
+            String blockComment = this.blockComment.toString();
+            if (!this.headerParsed) {
+                // Remove header from first key comment
+                blockComment = this.removeHeader(blockComment);
+                this.headerParsed = true;
+            }
+            this.setRawComment(node, blockComment, CommentType.BLOCK);
+            this.blockComment = null;
+        }
+        this.blockCommentStarted = false;
+    }
+
+    private void trackSideComment(final KeyTree.Node node) throws IOException {
+        if (node != null && this.currentLine != null) {
+            this.readValue();
+
+            // TODO Side comments below (dangling), matching indent with the current indent
+
+            if (this.isComment()) {
+                String sideComment = this.currentLine.substring(this.position);
+                if (!sideComment.isEmpty() && !this.isSpace(sideComment.charAt(0))) {
+                    sideComment = " " + sideComment;
+                }
+                this.setRawComment(node, sideComment, CommentType.SIDE);
             }
         }
+    }
+
+    private String removeHeader(String blockComment) {
+        final String header = this.options().headerFormatter().dump(this.options().header());
+        if (!header.isEmpty()) {
+            blockComment = blockComment.replaceFirst(Pattern.quote(header), "");
+            if (blockComment.isEmpty()) {
+                blockComment = null; // blockComment was the header
+            }
+        }
+        return blockComment;
     }
 
 }

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentParser.java
@@ -79,7 +79,7 @@ public class YamlCommentParser extends YamlCommentReader {
 
     private String removeHeader(String blockComment) {
         final String header = this.options().headerFormatter().dump(this.options().header());
-        if (!header.isEmpty()) {
+        if (header != null && !header.isEmpty()) {
             blockComment = blockComment.replaceFirst(Pattern.quote(header), "");
             if (blockComment.isEmpty()) {
                 blockComment = null; // blockComment was the header

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentReader.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentReader.java
@@ -146,6 +146,7 @@ public class YamlCommentReader extends YamlCommentMapper implements Closeable {
                     if (!hasNext || this.currentChar != QuoteStyle.SINGLE.getChar()) {
                         // Closing single quote
                         this.inQuote(QuoteStyle.NONE);
+                        this.isEscaping = false;
                     }
                     return hasNext;
                 }
@@ -203,11 +204,12 @@ public class YamlCommentReader extends YamlCommentMapper implements Closeable {
         while (this.nextChar() && this.stage != ReaderStage.QUOTE_OPEN) {
             if (this.isSpace(this.currentChar)) {
                 indent++;
-            } else if (this.isSpecialIndent(this.currentChar) && this.hasNext()
-                    && this.isSpace(this.currentLine.charAt(this.position + 1))) {
-                indent += 2;
-                this.nextChar();
             } else {
+                if (this.isSpecialIndent(this.currentChar) && this.hasNext()
+                        && this.isSpace(this.currentLine.charAt(this.position + 1))) {
+                    // Skip special indent (do not increment indent)
+                    this.nextChar();
+                }
                 break;
             }
         }

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentReader.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlCommentReader.java
@@ -4,25 +4,28 @@ import org.simpleyaml.configuration.file.YamlConfigurationOptions;
 import org.simpleyaml.utils.Validate;
 
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.regex.MatchResult;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-public class YamlCommentReader extends YamlCommentMapper {
+public class YamlCommentReader extends YamlCommentMapper implements Closeable {
 
-    private static final Pattern KEY_REGEX = Pattern.compile("^([ \\t-]*)([^#]*?)[ \\t]*:.*");
-
-    private static final Pattern ELEMENT_REGEX = Pattern.compile("^([ \\t-]*)([^#\\n]*[^#\\s-]+).*");
-
-    private static final Pattern OTHER_REGEX = Pattern.compile("^([ \\t-]*).*");
-
-    protected BufferedReader reader;
+    protected final BufferedReader reader;
 
     protected String currentLine;
-
     protected String trim;
+
+    protected int indent;
+    protected String key;
+
+    protected int position = -1;
+    protected char currentChar;
+
+    protected boolean isEscaping = false;
+    protected boolean isLiteral = false;
+    protected QuoteStyle quoteNotation = QuoteStyle.NONE;
+
+    protected ReaderStage stage = ReaderStage.START;
 
     protected YamlCommentReader(final YamlConfigurationOptions options, final Reader reader) {
         super(options);
@@ -30,51 +33,312 @@ public class YamlCommentReader extends YamlCommentMapper {
         this.reader = new BufferedReader(reader);
     }
 
+    protected boolean nextLine() throws IOException {
+        this.currentLine = this.reader.readLine();
+        this.position = -1;
+        this.currentChar = '\0';
+        if (this.currentLine != null) {
+            this.stage = ReaderStage.NEW_LINE;
+            int indent = this.readIndent();
+            this.checkLiteral(indent);
+            this.trim = this.currentLine.substring(indent).trim();
+            return true;
+        } else {
+            this.indent = 0;
+            this.trim = null;
+            this.stage = ReaderStage.END_OF_FILE;
+            return false;
+        }
+    }
+
+    protected boolean nextChar() {
+        this.position++;
+        if (this.position < this.currentLine.length()) {
+            this.currentChar = this.currentLine.charAt(this.position);
+            return this.checkSpecials();
+        }
+        this.stage = ReaderStage.END_OF_LINE;
+        return false;
+    }
+
+    protected boolean hasChar() {
+        return this.stage != ReaderStage.END_OF_LINE && this.stage != ReaderStage.END_OF_FILE;
+    }
+
+    protected boolean hasNext() {
+        return this.position + 1 < this.currentLine.length();
+    }
+
     protected boolean isBlank() {
         return this.trim.isEmpty();
     }
 
-    protected boolean isComment() {
-        return this.trim.startsWith("#");
+    protected boolean isSpace(char c) {
+        return c == ' ' || c == '\t';
     }
 
-    protected boolean nextLine() throws IOException {
-        this.currentLine = this.reader.readLine();
-        if (this.currentLine != null) {
-            this.trim = this.currentLine.trim();
+    protected boolean isSpecialIndent(char c) {
+        return c == '-' || c == '?' || c == ':';
+    }
+
+    protected boolean isComment() {
+        if (this.stage == ReaderStage.COMMENT) {
+            return true;
+        }
+        if (this.currentChar == '#' && this.canStartComment()) {
+            this.stage = ReaderStage.COMMENT;
             return true;
         }
         return false;
     }
 
-    protected KeyTree.Node track() {
-        int indent = 0;
-        String key = null;
-        if (this.currentLine != null) {
-            final MatchResult groups = this.match(this.currentLine);
-            indent = groups.group(1).length();
-            if (groups.groupCount() > 1) {
-                key = groups.group(2);
+    protected boolean canStartComment() {
+        return this.position == 0 || this.stage == ReaderStage.QUOTE_CLOSE ||
+                (!this.isInQuote() && this.position > 0 && isSpace(this.currentLine.charAt(this.position - 1)));
+    }
+
+    protected boolean isInQuote() {
+        return this.quoteNotation != QuoteStyle.NONE;
+    }
+
+    protected boolean isLiteralChar() {
+        return this.currentChar == '|' || this.currentChar == '>';
+    }
+
+    protected void checkLiteral(final int indent) {
+        if (this.isLiteral) {
+            if (this.quoteNotation != QuoteStyle.LITERAL) {
+                // First line of the block scalar literal
+                this.quoteNotation = QuoteStyle.LITERAL;
+            } else if (indent <= this.indent) {
+                // Indentation reset, block scalar literal finished
+                this.quoteNotation = QuoteStyle.NONE;
+                this.isLiteral = false;
+                this.indent = indent;
+            }
+        } else {
+            this.indent = indent;
+        }
+    }
+
+    protected boolean checkSpecials() {
+        if (this.quoteNotation == QuoteStyle.NONE) {
+            // Default notation
+            if (this.stage == ReaderStage.NEW_LINE || this.stage == ReaderStage.AFTER_KEY) {
+                // Check opening quote
+                if (this.currentChar == QuoteStyle.SINGLE.getChar()) {
+                    this.inQuote(QuoteStyle.SINGLE);
+                    return this.nextChar();
+                } else if (this.currentChar == QuoteStyle.DOUBLE.getChar()) {
+                    this.inQuote(QuoteStyle.DOUBLE);
+                    return this.nextChar();
+                } else if (this.stage == ReaderStage.AFTER_KEY && this.isLiteralChar()) {
+                    this.isLiteral = true; // Flag new lines to be a block scalar literal until indentation resets
+                }
+            }
+        } else if (this.quoteNotation == QuoteStyle.SINGLE) {
+            // Single quote notation
+            if (!this.isEscaping) {
+                if (this.currentChar == QuoteStyle.SINGLE.getChar()) {
+                    // Check if it is an escape or closing quote
+                    this.isEscaping = true;
+                    boolean hasNext = this.nextChar();
+                    if (!hasNext || this.currentChar != QuoteStyle.SINGLE.getChar()) {
+                        // Closing single quote
+                        this.inQuote(QuoteStyle.NONE);
+                    }
+                    return hasNext;
+                }
+            } else {
+                this.isEscaping = false;
+            }
+        } else if (this.quoteNotation == QuoteStyle.DOUBLE) {
+            // Double quote notation
+            if (!this.isEscaping) {
+                if (this.currentChar == this.quoteNotation.getChar()) {
+                    // Closing double quote
+                    this.inQuote(QuoteStyle.NONE);
+                    return this.nextChar();
+                } else if (this.currentChar == '\\') {
+                    this.isEscaping = true;
+                    return this.nextChar();
+                }
+            } else {
+                this.isEscaping = false;
             }
         }
+        return true;
+    }
+
+    protected void inQuote(QuoteStyle quoteStyle) {
+        this.quoteNotation = quoteStyle;
+
+        if (quoteStyle == QuoteStyle.NONE) {
+            this.stage = ReaderStage.QUOTE_CLOSE;
+        } else {
+            this.stage = ReaderStage.QUOTE_OPEN;
+        }
+    }
+
+    protected boolean isSectionKey() {
+        if (this.currentChar == ':' && (this.stage == ReaderStage.KEY || this.stage == ReaderStage.QUOTE_CLOSE)) {
+            if (this.hasNext()) {
+                if (this.isSpace(this.currentLine.charAt(this.position + 1))) {
+                    // space after colon, valid key
+                    this.nextChar();
+                    this.stage = ReaderStage.AFTER_KEY;
+                    return true;
+                }
+                // no space after colon, thus the colon is not a key-value delimiter
+                return false;
+            }
+            // end of line after colon, valid key
+            return true;
+        }
+        return false;
+    }
+
+    protected int readIndent() {
+        int indent = 0;
+        while (this.nextChar() && this.stage != ReaderStage.QUOTE_OPEN) {
+            if (this.isSpace(this.currentChar)) {
+                indent++;
+            } else if (this.isSpecialIndent(this.currentChar) && this.hasNext()
+                    && this.isSpace(this.currentLine.charAt(this.position + 1))) {
+                indent += 2;
+                this.nextChar();
+            } else {
+                break;
+            }
+        }
+        return indent;
+    }
+
+    protected String readKey() {
+        String key = null;
+
+        if (this.currentLine != null) {
+            StringBuilder keyBuilder = new StringBuilder();
+
+            boolean hasChar = this.hasChar();
+            boolean withinQuotes = this.isInQuote();
+
+            while (hasChar && !this.isSectionKey() && this.stage != ReaderStage.QUOTE_CLOSE && !this.isComment()) {
+                this.stage = ReaderStage.KEY;
+                keyBuilder.append(this.currentChar);
+                hasChar = this.nextChar();
+            }
+
+            key = keyBuilder.toString();
+
+            if (!withinQuotes) {
+                key = key.trim();
+            }
+        }
+
+        return key;
+    }
+
+    protected void readValue() throws IOException {
+        boolean hasChar = this.hasChar();
+        boolean endOfValue = !hasChar || this.isComment();
+
+        if (!endOfValue) {
+            hasChar = this.nextChar();
+            if (hasChar && this.stage != ReaderStage.QUOTE_CLOSE) {
+                this.stage = ReaderStage.VALUE;
+            }
+            endOfValue = !hasChar || this.isComment();
+        }
+
+        while (!endOfValue) {
+            hasChar = this.nextChar();
+            endOfValue = !hasChar || this.isComment();
+        }
+
+        if (this.isMultiline() && this.nextLine()) {
+            this.readValue();
+        }
+
+        if (this.isComment()) {
+            // Do not skip the comment indent
+            this.position--;
+            while (this.position >= 0 && this.isSpace(this.currentLine.charAt(this.position))) {
+                this.position--;
+            }
+            this.position++;
+        }
+
+        // Value is not stored because is not relevant to track comments (we are only handling quotes and literal blocks here)
+    }
+
+    protected final boolean isMultiline() {
+        return !this.hasChar() && this.isInQuote();
+    }
+
+    protected KeyTree.Node track() throws IOException {
+        if (this.quoteNotation == QuoteStyle.LITERAL) {
+            return null;
+        }
+        this.key = this.readKey();
+        return this.track(this.indent, this.key);
+    }
+
+    protected KeyTree.Node track(final int indent, final String key) {
         final KeyTree.Node parent = this.keyTree.findParent(indent);
         return parent.add(indent, key);
     }
 
-    private MatchResult match(final String s) {
-        Matcher matcher = YamlCommentReader.KEY_REGEX.matcher(s); // for comments of section keys
-        if (matcher.matches()) {
-            return matcher.toMatchResult();
+    @Override
+    public void close() throws IOException {
+        this.reader.close();
+    }
+
+    @Override
+    public String toString() {
+        return "YamlCommentReader{" +
+                "currentLine='" + currentLine + '\'' +
+                ", trim='" + trim + '\'' +
+                ", stage=" + stage +
+                ", indent=" + indent +
+                ", key='" + key + '\'' +
+                ", position=" + position +
+                ", currentChar=" + currentChar +
+                ", isEscaping=" + isEscaping +
+                ", isLiteral=" + isLiteral +
+                ", quoteNotation=" + quoteNotation +
+                ", keyTree=" + keyTree +
+                '}';
+    }
+
+    protected enum ReaderStage {
+        START,
+        NEW_LINE,
+        KEY,
+        AFTER_KEY,
+        VALUE,
+        COMMENT,
+        QUOTE_OPEN,
+        QUOTE_CLOSE,
+        END_OF_LINE,
+        END_OF_FILE
+    }
+
+    public enum QuoteStyle {
+        NONE ('\0'),
+        SINGLE ('\''),
+        DOUBLE ('"'),
+        LITERAL ('|');
+
+        private final char quote;
+
+        QuoteStyle(char quote) {
+            this.quote = quote;
         }
-        matcher = YamlCommentReader.ELEMENT_REGEX.matcher(s); // for comments of section values
-        if (matcher.matches()) {
-            return matcher.toMatchResult();
+
+        public char getChar() {
+            return this.quote;
         }
-        matcher = YamlCommentReader.OTHER_REGEX.matcher(s); // for anything else
-        if (matcher.matches()) {
-            return matcher.toMatchResult();
-        }
-        throw new IllegalStateException(s + " cannot be matched");
     }
 
 }

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlHeaderFormatter.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlHeaderFormatter.java
@@ -1,0 +1,235 @@
+package org.simpleyaml.configuration.comments;
+
+import org.simpleyaml.utils.StringUtils;
+import org.simpleyaml.utils.Validate;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Objects;
+
+import static org.simpleyaml.configuration.comments.YamlCommentFormatterConfiguration.DEFAULT_COMMENT_PREFIX;
+import static org.simpleyaml.utils.StringUtils.BLANK_LINE;
+
+/**
+ * The header is the first block comment at the top of the configuration file.
+ * <p></p>
+ * It ends with a blank line or with the end of the file.
+ */
+public class YamlHeaderFormatter implements CommentFormatter {
+
+    protected YamlCommentFormatterConfiguration configuration;
+
+    protected YamlHeaderFormatter(YamlCommentFormatterConfiguration configuration) {
+        Validate.notNull(configuration);
+        this.configuration = configuration;
+    }
+
+    public YamlHeaderFormatter(String commentPrefix, boolean strip) {
+        this(new YamlCommentFormatterConfiguration().prefix(commentPrefix).stripPrefix(strip).suffix(BLANK_LINE));
+    }
+
+    public YamlHeaderFormatter() {
+        this(DEFAULT_COMMENT_PREFIX, false);
+    }
+
+    /**
+     * Parse the header of a contents string, like a file contents.
+     * <p></p>
+     * The header is the first block comment at the top of the configuration file.
+     * It ends with a blank line or with the end of the file.
+     * <p></p>
+     * If no blank line is found after the first block comment and it is not the end of the file then null is returned
+     * (the comment will be attached to the first key, so that comment is not considered a header).
+     * <p></p>
+     * The blank line suffix will be stripped away, i.e. the result string will not have a blank line at the end.
+     * <p></p>
+     * If {@link #stripPrefix} is true then {@link String#trim()} will be applied to every line of the header
+     * and the {@link #commentPrefix()} will be stripped away.
+     *
+     * @param contents the string to parse
+     * @return the header
+     */
+    public String parse(String contents, CommentType type, KeyTree.Node node) {
+        final StringBuilder headerBuilder = new StringBuilder();
+        try {
+            // using buffered reader to avoid processing and allocating the whole contents as with split lines
+            final BufferedReader reader = new BufferedReader(new StringReader(contents));
+            boolean headerFound = false;
+            String line, trim;
+            while ((line = reader.readLine()) != null) {
+                trim = line.trim();
+                if (trim.isEmpty()) {
+                    if (headerFound) {
+                        break; // stop at the first blank line after header comment
+                    }
+                    headerBuilder.append('\n');
+                } else if (trim.startsWith(YamlCommentFormatterConfiguration.COMMENT_INDICATOR)) {
+                    if (this.stripPrefix()) {
+                        // append comment without comment prefix and ignore leading and trailing spaces
+                        line = StringUtils.stripPrefix(trim, this.commentPrefix(), YamlCommentFormatterConfiguration.COMMENT_INDICATOR);
+                    }
+                    if (headerFound) {
+                        headerBuilder.append('\n'); // there was a previous comment, adding a new line before this line
+                        // this achieves that no \n is added to the end of the whole comment
+                    } else {
+                        headerFound = true;
+                    }
+                    headerBuilder.append(line);
+                } else {
+                    // key found before blank line, so the comment is considered to be the first key block comment
+                    return null; // no header
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot parse header", e);
+        }
+        return headerBuilder.toString();
+    }
+
+    /**
+     * Given the header (for instance the one returned by {@link #parse}),
+     * returns the final string formatted to be dumped somewhere like a file.
+     * <p></p>
+     * The header ends with a blank line and every line is prefixed with the {@link #commentPrefix()}.
+     * <p>
+     * If all header lines are already prefixed with a # then the {@link #commentPrefix()} is not applied.
+     * @param header the header to dump
+     * @return the final string to be dumped
+     */
+    public String dump(String header, CommentType type, KeyTree.Node node) {
+        String prefixFirst = null, prefixMultiline = null;
+        String suffixLast = null, suffixMultiline = null;
+        if (header != null) {
+            // All header lines must be prefixed with #, with no blank lines
+            if (!StringUtils.allLinesArePrefixed(header, YamlCommentFormatterConfiguration.COMMENT_INDICATOR)) {
+                prefixMultiline = this.commentPrefix();
+                prefixFirst = this.configuration.prefixFirst(prefixMultiline);
+                suffixMultiline = this.configuration.suffixMultiline();
+
+                // Ensure the first line has the prefix multiline
+                if (!prefixFirst.equals(prefixMultiline)) {
+                    final String prefixFirstSuffix = '\n' + prefixMultiline;
+                    if (!prefixFirst.endsWith(prefixFirstSuffix)) {
+                        prefixFirst += prefixFirstSuffix;
+                    }
+                }
+            }
+            // Header must end with the configuration suffix (a blank line by default)
+            if (!header.endsWith(configuration.suffixLast())) {
+                suffixLast = configuration.suffixLast();
+            }
+            // Ensure the last line has the suffix multiline
+            if (suffixLast != null && suffixMultiline != null && !suffixMultiline.isEmpty()) {
+                final String suffixLastPrefix = suffixMultiline + '\n';
+                if (!suffixLast.startsWith(suffixLastPrefix)) {
+                    suffixLast = suffixLastPrefix + suffixLast;
+                }
+            }
+        }
+        return CommentFormatter.format(prefixFirst, prefixMultiline, header, suffixMultiline, suffixLast);
+    }
+
+    /**
+     * If strip is true then {@link String#trim()} will be applied to every line of the header
+     * and the {@link #commentPrefix()} will be stripped away.
+     * <p></p>
+     * Default is false.
+     * @return if stripping the prefix is desired
+     */
+    public boolean stripPrefix() {
+        return this.configuration.stripPrefix();
+    }
+
+    /**
+     * Set if stripping the prefix is desired.
+     * <p></p>
+     * If strip is true then {@link String#trim()} will be applied to every line of the header
+     * and the {@link #commentPrefix()} will be stripped away.
+     * <p></p>
+     * Default is false.
+     * @param stripPrefix if stripping the prefix is desired
+     * @return this object, for chaining
+     */
+    public YamlHeaderFormatter stripPrefix(final boolean stripPrefix) {
+        this.configuration.stripPrefix(stripPrefix);
+        return this;
+    }
+
+    /**
+     * Gets the comment prefix to apply to every line of the header.
+     * <p></p>
+     * By default is "# ", i.e. a # followed by a space.
+     * @return the comment prefix
+     */
+    public String commentPrefix() {
+        return this.configuration.prefixMultiline(DEFAULT_COMMENT_PREFIX);
+    }
+
+    /**
+     * Sets the comment prefix to apply to every line of the header.
+     * <p></p>
+     * By default is "# ", i.e. a # followed by a space.
+     * @param commentPrefix the comment prefix
+     * @return this object, for chaining
+     */
+    public YamlHeaderFormatter commentPrefix(final String commentPrefix) {
+        String prefixFirst = this.configuration.prefixFirst(DEFAULT_COMMENT_PREFIX);
+        if (prefixFirst.equals(DEFAULT_COMMENT_PREFIX)) {
+            prefixFirst = commentPrefix;
+        }
+        this.configuration.prefix(prefixFirst, commentPrefix);
+        return this;
+    }
+
+    /**
+     * Sets the comment prefix to apply to the beginning of the header.
+     * @param commentPrefixFirst the comment prefix to apply to the beginning of the header
+     * @return this object, for chaining
+     */
+    public YamlHeaderFormatter prefixFirst(String commentPrefixFirst) {
+        this.configuration.prefix(commentPrefixFirst, this.commentPrefix());
+        return this;
+    }
+
+    /**
+     * Set the comment suffix to append to every line of the header.
+     * @param suffixMultiline the suffix to append to every line of the header
+     * @return this object, for chaining
+     */
+    public YamlHeaderFormatter commentSuffix(String suffixMultiline) {
+        this.configuration.suffix(this.configuration.suffixLast(BLANK_LINE), suffixMultiline);
+        return this;
+    }
+
+    /**
+     * Set the suffix to append to the end of the header.
+     * If not included, a blank line \n\n will be added to the suffix.
+     * <p></p>
+     * Default is a blank line.
+     * @param suffixLast the suffix to append to the end of the header
+     * @return this object, for chaining
+     */
+    public YamlHeaderFormatter suffixLast(String suffixLast) {
+        if (suffixLast == null) {
+            suffixLast = BLANK_LINE;
+        } else if (!suffixLast.endsWith(BLANK_LINE)) {
+            suffixLast += BLANK_LINE;
+        }
+        this.configuration.suffix(suffixLast);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        YamlHeaderFormatter that = (YamlHeaderFormatter) o;
+        return Objects.equals(configuration, that.configuration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(configuration);
+    }
+}

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlSideCommentFormatterConfiguration.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/comments/YamlSideCommentFormatterConfiguration.java
@@ -1,0 +1,70 @@
+package org.simpleyaml.configuration.comments;
+
+import org.simpleyaml.utils.Validate;
+
+public class YamlSideCommentFormatterConfiguration extends YamlCommentFormatterConfiguration {
+
+    public static final String DEFAULT_SIDE_COMMENT_PREFIX = " " + DEFAULT_COMMENT_PREFIX;
+
+    public YamlSideCommentFormatterConfiguration() {
+        this(DEFAULT_SIDE_COMMENT_PREFIX);
+    }
+
+    public YamlSideCommentFormatterConfiguration(String sidePrefix) {
+        super(sidePrefix);
+    }
+
+    public YamlSideCommentFormatterConfiguration(String sidePrefix, String prefixMultiline) {
+        super(sidePrefix, prefixMultiline);
+    }
+
+    @Override
+    public YamlSideCommentFormatterConfiguration prefix(String sidePrefix) {
+        super.prefix(sidePrefix, DEFAULT_COMMENT_PREFIX);
+        return this;
+    }
+
+    @Override
+    public YamlSideCommentFormatterConfiguration prefix(String prefixFirst, String prefixMultiline) {
+        super.prefix(prefixFirst, prefixMultiline);
+        return this;
+    }
+
+    @Override
+    public YamlSideCommentFormatterConfiguration suffix(String suffixLast) {
+        super.suffix(suffixLast);
+        return this;
+    }
+
+    @Override
+    public YamlSideCommentFormatterConfiguration suffix(String suffixLast, String suffixMultiline) {
+        super.suffix(suffixLast, suffixMultiline);
+        return this;
+    }
+
+    @Override
+    public YamlSideCommentFormatterConfiguration trim(boolean trim) {
+        super.trim(trim);
+        return this;
+    }
+
+    @Override
+    public YamlSideCommentFormatterConfiguration stripPrefix(boolean stripPrefix) {
+        super.stripPrefix(stripPrefix);
+        return this;
+    }
+
+    @Override
+    public void checkCommentPrefix(final String sidePrefix) {
+        Validate.isTrue(sidePrefix != null
+                        && !sidePrefix.isEmpty()
+                        && Character.isWhitespace(sidePrefix.charAt(0)),
+                "Side comment prefix must start with space");
+        super.checkCommentPrefix(sidePrefix);
+    }
+
+    @Override
+    public void checkCommentPrefixMultiline(final String commentPrefix) {
+        super.checkCommentPrefix(commentPrefix);
+    }
+}

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/file/YamlConfiguration.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/file/YamlConfiguration.java
@@ -99,12 +99,14 @@ public class YamlConfiguration extends FileConfiguration {
     protected String dump() {
         this.yamlOptions.setAllowUnicode(this.options().isUnicode());
 
-        this.yamlOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-        this.yamlRepresenter.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-
         this.yamlOptions.setIndent(this.options().indent());
         this.yamlOptions.setIndicatorIndent(this.options().indentList());
         this.yamlOptions.setIndentWithIndicator(true);
+
+        this.yamlOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        this.yamlRepresenter.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+
+        this.yamlRepresenter.setDefaultScalarStyle(DumperOptions.ScalarStyle.PLAIN);
 
         String dump = this.yaml.dump(this.getValues(false));
 

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/file/YamlConfigurationOptions.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/file/YamlConfigurationOptions.java
@@ -1,6 +1,7 @@
 package org.simpleyaml.configuration.file;
 
 import org.simpleyaml.configuration.comments.CommentFormatter;
+import org.simpleyaml.configuration.comments.YamlCommentFormat;
 import org.simpleyaml.configuration.comments.YamlHeaderFormatter;
 import org.simpleyaml.configuration.comments.YamlCommentFormatter;
 import org.simpleyaml.utils.Validate;
@@ -112,13 +113,13 @@ public class YamlConfigurationOptions extends FileConfigurationOptions {
     /**
      * Gets the comment formatter used to format comments.
      * <p></p>
-     * The default comment formatter prefix is "# ", i.e. a # followed by a space.
+     * The default comment formatter is {@link YamlCommentFormat#DEFAULT}, which comment prefix is "# ", i.e. a # followed by a space.
      *
      * @return the comment formatter
      */
     public YamlCommentFormatter commentFormatter() {
         if (this.commentFormatter == null) {
-            this.commentFormatter = new YamlCommentFormatter();
+            this.commentFormatter = YamlCommentFormat.DEFAULT.commentFormatter();
         }
         return this.commentFormatter;
     }

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/file/YamlConfigurationOptions.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/file/YamlConfigurationOptions.java
@@ -1,5 +1,8 @@
 package org.simpleyaml.configuration.file;
 
+import org.simpleyaml.configuration.comments.CommentFormatter;
+import org.simpleyaml.configuration.comments.YamlHeaderFormatter;
+import org.simpleyaml.configuration.comments.YamlCommentFormatter;
 import org.simpleyaml.utils.Validate;
 
 import java.util.Objects;
@@ -8,15 +11,19 @@ import java.util.Objects;
  * Various settings for controlling the input and output of a {@link YamlConfiguration}
  *
  * @author Bukkit
- * @author Carlos Lazaro Costa (added indentList option)
+ * @author Carleslc
  * @see <a href="https://github.com/Bukkit/Bukkit/tree/master/src/main/java/org/bukkit/configuration/file/YamlConfigurationOptions.java">Bukkit Source</a>
  */
 public class YamlConfigurationOptions extends FileConfigurationOptions {
 
     private int indentList = 2;
 
+    private YamlCommentFormatter commentFormatter;
+
     protected YamlConfigurationOptions(final YamlConfiguration configuration) {
         super(configuration);
+
+        this.headerFormatter(new YamlHeaderFormatter());
     }
 
     @Override
@@ -37,8 +44,8 @@ public class YamlConfigurationOptions extends FileConfigurationOptions {
     }
 
     @Override
-    public YamlConfigurationOptions header(final String value) {
-        super.header(value);
+    public YamlConfigurationOptions header(final String header) {
+        super.header(header);
         return this;
     }
 
@@ -46,6 +53,18 @@ public class YamlConfigurationOptions extends FileConfigurationOptions {
     public YamlConfigurationOptions copyHeader(final boolean value) {
         super.copyHeader(value);
         return this;
+    }
+
+    @Override
+    public YamlConfigurationOptions headerFormatter(final CommentFormatter headerFormatter) {
+        Validate.isTrue(headerFormatter instanceof YamlHeaderFormatter, "The header formatter must inherit YamlHeaderFormatter");
+        super.headerFormatter(headerFormatter);
+        return this;
+    }
+
+    @Override
+    public YamlHeaderFormatter headerFormatter() {
+        return (YamlHeaderFormatter) super.headerFormatter();
     }
 
     /**
@@ -90,17 +109,44 @@ public class YamlConfigurationOptions extends FileConfigurationOptions {
         return this;
     }
 
+    /**
+     * Gets the comment formatter used to format comments.
+     * <p></p>
+     * The default comment formatter prefix is "# ", i.e. a # followed by a space.
+     *
+     * @return the comment formatter
+     */
+    public YamlCommentFormatter commentFormatter() {
+        if (this.commentFormatter == null) {
+            this.commentFormatter = new YamlCommentFormatter();
+        }
+        return this.commentFormatter;
+    }
+
+    /**
+     * Sets the comment formatter to be used to format comments.
+     * <p></p>
+     * If unset, the default comment formatter prefix is "# ", i.e. a # followed by a space.
+     *
+     * @param commentFormatter the comment formatter to use
+     * @return This object, for chaining
+     */
+    public YamlConfigurationOptions commentFormatter(final YamlCommentFormatter commentFormatter) {
+        this.commentFormatter = commentFormatter;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof YamlConfigurationOptions)) return false;
         if (!super.equals(o)) return false;
         YamlConfigurationOptions that = (YamlConfigurationOptions) o;
-        return indentList == that.indentList;
+        return indentList == that.indentList && Objects.equals(commentFormatter, that.commentFormatter);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), indentList);
+        return Objects.hash(super.hashCode(), indentList, commentFormatter);
     }
 }

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/file/YamlFile.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/file/YamlFile.java
@@ -169,13 +169,15 @@ public class YamlFile extends YamlConfiguration implements Commentable {
     }
 
     /**
-     * Adds a comment to the section or value selected by path.
+     * Set a comment to the section or value selected by path.
      * Comment will be indented automatically.
      * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of {@link #options()} {@link YamlConfigurationOptions#commentFormatter()}.
      *
-     * @param path    path of desired section or value
-     * @param comment the comment to add, # symbol is not needed
-     * @param type    either above (block) or side
+     * @param path    path of desired section or key
+     * @param comment the comment to add, # prefix is not needed
+     * @param type    either above (BLOCK) or SIDE
      */
     @Override
     public void setComment(final String path, final String comment, final CommentType type) {
@@ -186,19 +188,217 @@ public class YamlFile extends YamlConfiguration implements Commentable {
         this.yamlCommentMapper.setComment(path, comment, type);
     }
 
-    // TODO add YamlCommentFormat DEFAULT (no blank lines), PRETTY (blank line above comment if indent is 0)
+    /**
+     * Set a block comment above the section or value selected by path.
+     * Comment will be indented automatically.
+     * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of {@link #options()} {@link YamlConfigurationOptions#commentFormatter()}.
+     *
+     * @param path    path of desired section or key
+     * @param comment the block comment to add, # character is not needed
+     */
+    public void setComment(final String path, final String comment) {
+        this.setComment(path, comment, CommentType.BLOCK);
+    }
+
+    /**
+     * Set a comment to the section or value selected by path.
+     * Comment will be indented automatically.
+     * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormatter}.
+     *
+     * @param path    path of desired section or key
+     * @param comment the comment to add, # prefix is not needed
+     * @param type    either above (BLOCK) or SIDE
+     * @param yamlCommentFormatter the comment formatter to use
+     */
+    public void setComment(final String path, final String comment, final CommentType type, final YamlCommentFormatter yamlCommentFormatter) {
+        final YamlCommentFormatter defaultFormatter = this.options().commentFormatter();
+        this.setCommentFormat(yamlCommentFormatter);
+        this.setComment(path, comment, type);
+        this.setCommentFormat(defaultFormatter);
+    }
+
+    /**
+     * Set a comment to the section or value selected by path.
+     * Comment will be indented automatically.
+     * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormat}.
+     *
+     * @param path    path of desired section or key
+     * @param comment the comment to add, # prefix is not needed
+     * @param type    either above (BLOCK) or SIDE
+     * @param yamlCommentFormat the comment format to use
+     */
+    public void setComment(final String path, final String comment, final CommentType type, final YamlCommentFormat yamlCommentFormat) {
+        Validate.notNull(yamlCommentFormat, "yamlCommentFormat cannot be null!");
+        this.setComment(path, comment, type, yamlCommentFormat.commentFormatter());
+    }
+
+    /**
+     * Set a block comment to the section or value selected by path.
+     * Comment will be indented automatically.
+     * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormatter}.
+     *
+     * @param path    path of desired section or key
+     * @param comment the block comment to add, # prefix is not needed
+     * @param yamlCommentFormatter the comment formatter to use
+     */
+    public void setComment(final String path, final String comment, final YamlCommentFormatter yamlCommentFormatter) {
+        this.setComment(path, comment, CommentType.BLOCK, yamlCommentFormatter);
+    }
+
+    /**
+     * Set a block comment to the section or value selected by path.
+     * Comment will be indented automatically.
+     * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormat}.
+     *
+     * @param path    path of desired section or key
+     * @param comment the block comment to add, # prefix is not needed
+     * @param yamlCommentFormat the comment format to use
+     */
+    public void setComment(final String path, final String comment, final YamlCommentFormat yamlCommentFormat) {
+        this.setComment(path, comment, CommentType.BLOCK, yamlCommentFormat);
+    }
+
+    /**
+     * Set a blank line at the beginning of the block comment.
+     * If currently there is no block comment for the provided path then it sets "\n" as the block comment.
+     * @param path path of desired section or key
+     */
+    public void setBlankLine(final String path) {
+        final YamlCommentFormatter defaultFormatter = this.options().commentFormatter();
+        this.setCommentFormat(YamlCommentFormat.RAW);
+        final String comment = this.getComment(path, CommentType.BLOCK);
+        if (comment == null) {
+            this.setComment(path, "\n", CommentType.BLOCK);
+        } else if (!comment.startsWith("\n")) {
+            this.setComment(path, '\n' + comment, CommentType.BLOCK);
+        }
+        this.setCommentFormat(defaultFormatter);
+    }
 
     /**
      * Retrieve the comment of the section or value selected by path.
+     * <p></p>
+     * Comment format will follow the rules of {@link #options()} {@link YamlConfigurationOptions#commentFormatter()}.
      *
-     * @param path path of desired section or value
-     * @param type either above (block) or side
+     * @param path path of desired section or key
+     * @param type either above (BLOCK) or SIDE
      * @return the comment of the section or value selected by path,
      * or null if that path does not have any comment of this type
      */
     @Override
     public String getComment(final String path, final CommentType type) {
         return this.yamlCommentMapper != null ? this.yamlCommentMapper.getComment(path, type) : null;
+    }
+
+    /**
+     * Retrieve the block comment of the section or value selected by path.
+     * <p></p>
+     * Comment format will follow the rules of {@link #options()} {@link YamlConfigurationOptions#commentFormatter()}.
+     *
+     * @param path path of desired section or key
+     * @return the block comment of the section or value selected by path,
+     * or null if that path does not have any comment of type block
+     */
+    public String getComment(final String path) {
+        return this.getComment(path, CommentType.BLOCK);
+    }
+
+    /**
+     * Retrieve the comment of the section or value selected by path.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormatter}.
+     *
+     * @param path path of desired section or key
+     * @param type either above (BLOCK) or SIDE
+     * @param yamlCommentFormatter the comment formatter to use
+     * @return the comment of the section or value selected by path,
+     * or null if that path does not have any comment of this type
+     */
+    public String getComment(final String path, final CommentType type, final YamlCommentFormatter yamlCommentFormatter) {
+        final YamlCommentFormatter defaultFormatter = this.options().commentFormatter();
+        this.setCommentFormat(yamlCommentFormatter);
+        final String comment = this.getComment(path, type);
+        this.setCommentFormat(defaultFormatter);
+        return comment;
+    }
+
+    /**
+     * Retrieve the comment of the section or value selected by path.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormat}.
+     *
+     * @param path path of desired section or key
+     * @param type either above (BLOCK) or SIDE
+     * @param yamlCommentFormat the comment format to use
+     * @return the comment of the section or value selected by path,
+     * or null if that path does not have any comment of this type
+     */
+    public String getComment(final String path, final CommentType type, final YamlCommentFormat yamlCommentFormat) {
+        Validate.notNull(yamlCommentFormat, "yamlCommentFormat cannot be null!");
+        return this.getComment(path, type, yamlCommentFormat.commentFormatter());
+    }
+
+    /**
+     * Retrieve the block comment of the section or value selected by path.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormatter}.
+     *
+     * @param path path of desired section or key
+     * @param yamlCommentFormatter the comment formatter to use
+     * @return the block comment of the section or value selected by path,
+     * or null if that path does not have any comment of type block
+     */
+    public String getComment(final String path, final YamlCommentFormatter yamlCommentFormatter) {
+        return this.getComment(path, CommentType.BLOCK, yamlCommentFormatter);
+    }
+
+    /**
+     * Retrieve the block comment of the section or value selected by path.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormat}.
+     *
+     * @param path path of desired section or key
+     * @param yamlCommentFormat the comment format to use
+     * @return the block comment of the section or value selected by path,
+     * or null if that path does not have any comment of type block
+     */
+    public String getComment(final String path, final YamlCommentFormat yamlCommentFormat) {
+        return this.getComment(path, CommentType.BLOCK, yamlCommentFormat);
+    }
+
+    /**
+     * Change the comment formatter to one of the defaults provided by {@link YamlCommentFormat}.
+     * <p></p>
+     * This will change the behaviour for parsing comments with {@link #getComment(String, CommentType)}
+     * and for dumping comments with {@link #setComment(String, String, CommentType)}.
+     * If default behaviour does not suits you then change the format before calling one of these methods.
+     * @param yamlCommentFormat desired format to set/dump and get/parse comments
+     */
+    public void setCommentFormat(YamlCommentFormat yamlCommentFormat) {
+        Validate.notNull(yamlCommentFormat, "yamlCommentFormat cannot be null!");
+        this.setCommentFormat(yamlCommentFormat.commentFormatter());
+    }
+
+    /**
+     * Change the comment formatter for parsing and dumping comments.
+     * This is a shortcut to {@link #options()} {@link YamlConfigurationOptions#commentFormatter(YamlCommentFormatter)}.
+     * <p></p>
+     * This will change the behaviour for parsing comments with {@link #getComment(String, CommentType)}
+     * and for dumping comments with {@link #setComment(String, String, CommentType)}.
+     * @param yamlCommentFormatter desired formatter to set/dump and get/parse comments
+     */
+    public void setCommentFormat(YamlCommentFormatter yamlCommentFormatter) {
+        this.options().commentFormatter(yamlCommentFormatter);
     }
 
     /**
@@ -240,6 +440,7 @@ public class YamlFile extends YamlConfiguration implements Commentable {
 
     /**
      * Gets the footer of this configuration file.
+     * This is a shortcut to {@link #getComment(String)} with null path.
      * <p></p>
      * The string format will respect the rules of the {@link #options()} {@link YamlConfigurationOptions#commentFormatter()}.
      * <p></p>
@@ -253,6 +454,7 @@ public class YamlFile extends YamlConfiguration implements Commentable {
 
     /**
      * Sets the footer of this configuration file.
+     * This is a shortcut to {@link #setComment(String, String)} with null path.
      * <p></p>
      * This footer will be commented out and applied at the bottom of the generated output of this configuration file.
      * The end of the file will have a new line character '\n'.
@@ -263,6 +465,32 @@ public class YamlFile extends YamlConfiguration implements Commentable {
      */
     public void setFooter(String footer) {
         this.setComment(null, footer);
+    }
+
+    /**
+     * Get a wrapper builder to set a value to the given path and optionally set comments.
+     * <p></p>
+     * This is an alternative API for the following pattern:
+     * <pre>
+     * {@code
+     * yamlFile.set("test.hello", "Hello");
+     * yamlFile.setComment("test.hello", "Block comment");
+     * yamlFile.setComment("test.hello", "Side comment", CommentType.SIDE);
+     * }
+     * </pre>
+     * You can achieve the same with:
+     * <pre>
+     * {@code
+     * yamlFile.path("test.hello")
+     *         .set("Hello")
+     *         .comment("Block comment")
+     *         .commentSide("Side comment");
+     * }
+     * </pre>
+     * @param path path of the object or configuration to set
+     */
+    public YamlFileWrapper path(final String path) {
+        return new YamlFileWrapper(this, path);
     }
 
     /**
@@ -657,9 +885,8 @@ public class YamlFile extends YamlConfiguration implements Commentable {
         return config;
     }
 
+    @FunctionalInterface
     private interface YamlFileLoader {
-
         void load(YamlFile config) throws IOException, InvalidConfigurationException;
-
     }
 }

--- a/Simple-Yaml/src/main/java/org/simpleyaml/configuration/file/YamlFileWrapper.java
+++ b/Simple-Yaml/src/main/java/org/simpleyaml/configuration/file/YamlFileWrapper.java
@@ -1,0 +1,176 @@
+package org.simpleyaml.configuration.file;
+
+import org.simpleyaml.configuration.ConfigurationWrapper;
+import org.simpleyaml.configuration.comments.CommentType;
+import org.simpleyaml.configuration.comments.YamlCommentFormat;
+import org.simpleyaml.configuration.comments.YamlCommentFormatter;
+
+public class YamlFileWrapper extends ConfigurationWrapper<YamlFile> {
+
+    protected YamlFileWrapper(final YamlFile configuration, final String path, final YamlFileWrapper parent) {
+        super(configuration, path, parent);
+    }
+
+    public YamlFileWrapper(final YamlFile configuration, final String path) {
+        super(configuration, path);
+    }
+
+    /**
+     * Set a block comment above the section or value selected by path.
+     * Comment will be indented automatically.
+     * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of {@link YamlFile#options()} {@link YamlConfigurationOptions#commentFormatter()}.
+     *
+     * @param comment the block comment to add, # character is not needed
+     * @return this object, for chaining.
+     */
+    public YamlFileWrapper comment(final String comment) {
+        this.configuration.setComment(this.path, comment, CommentType.BLOCK);
+        return this;
+    }
+
+    /**
+     * Set a block comment to the section or value selected by path.
+     * Comment will be indented automatically.
+     * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormatter}.
+     *
+     * @param comment the block comment to add, # prefix is not needed
+     * @param yamlCommentFormatter the comment formatter to use
+     * @return this object, for chaining.
+     */
+    public YamlFileWrapper comment(final String comment, final YamlCommentFormatter yamlCommentFormatter) {
+        this.configuration.setComment(this.path, comment, CommentType.BLOCK, yamlCommentFormatter);
+        return this;
+    }
+
+    /**
+     * Set a block comment to the section or value selected by path.
+     * Comment will be indented automatically.
+     * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormat}.
+     *
+     * @param comment the block comment to add, # prefix is not needed
+     * @param yamlCommentFormat the comment format to use
+     * @return this object, for chaining.
+     */
+    public YamlFileWrapper comment(final String comment, final YamlCommentFormat yamlCommentFormat) {
+        this.configuration.setComment(this.path, comment, CommentType.BLOCK, yamlCommentFormat);
+        return this;
+    }
+
+    /**
+     * Set a side comment above the section or value selected by path.
+     * Comment will be indented automatically.
+     * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of {@link YamlFile#options()} {@link YamlConfigurationOptions#commentFormatter()}.
+     *
+     * @param comment the side comment to add, # symbol is not needed
+     * @return this object, for chaining.
+     */
+    public YamlFileWrapper commentSide(final String comment) {
+        this.configuration.setComment(this.path, comment, CommentType.SIDE);
+        return this;
+    }
+
+    /**
+     * Set a side comment to the section or value selected by path.
+     * Comment will be indented automatically.
+     * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormatter}.
+     *
+     * @param comment the side comment to add, # prefix is not needed
+     * @param yamlCommentFormatter the comment formatter to use
+     * @return this object, for chaining.
+     */
+    public YamlFileWrapper commentSide(final String comment, final YamlCommentFormatter yamlCommentFormatter) {
+        this.configuration.setComment(this.path, comment, CommentType.SIDE, yamlCommentFormatter);
+        return this;
+    }
+
+    /**
+     * Set a side comment to the section or value selected by path.
+     * Comment will be indented automatically.
+     * Multi-line comments can be provided using \n character.
+     * <p></p>
+     * Comment format will follow the rules of the provided {@link YamlCommentFormat}.
+     *
+     * @param comment the side to add, # prefix is not needed
+     * @param yamlCommentFormat the comment format to use
+     * @return this object, for chaining.
+     */
+    public YamlFileWrapper commentSide(final String comment, final YamlCommentFormat yamlCommentFormat) {
+        this.configuration.setComment(this.path, comment, CommentType.SIDE, yamlCommentFormat);
+        return this;
+    }
+
+    /**
+     * Set a blank line at the beginning of the block comment.
+     * If currently there is no block comment for this path then it sets "\n" as the block comment.
+     *
+     * @return this object, for chaining.
+     */
+    public YamlFileWrapper blankLine() {
+        apply(configuration::setBlankLine);
+        return this;
+    }
+
+    @Override
+    public YamlFileWrapper path(final String path) {
+        return new YamlFileWrapper(configuration, path, this);
+    }
+
+    @Override
+    public YamlFileWrapper set(final Object value) {
+        super.set(value);
+        return this;
+    }
+
+    @Override
+    public YamlFileWrapper set(final String path, final Object value) {
+        super.set(path, value);
+        return this;
+    }
+
+    @Override
+    public YamlFileWrapper addDefault(final Object value) {
+        super.addDefault(value);
+        return this;
+    }
+
+    @Override
+    public YamlFileWrapper addDefault(final String path, final Object value) {
+        super.addDefault(path, value);
+        return this;
+    }
+
+    @Override
+    public YamlFileWrapper createSection() {
+        super.createSection();
+        return this;
+    }
+
+    @Override
+    public YamlFileWrapper createSection(final String path) {
+        super.createSection(path);
+        return this;
+    }
+
+    @Override
+    public YamlFileWrapper parent() {
+        if (this.parent == null && this.path != null) {
+            int lastSectionIndex = this.path.lastIndexOf(this.configuration.options().pathSeparator());
+
+            if (lastSectionIndex >= 0) {
+                return new YamlFileWrapper(this.configuration, this.path.substring(0, lastSectionIndex));
+            }
+        }
+        return (YamlFileWrapper) this.parent;
+    }
+
+}

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentDumperTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentDumperTest.java
@@ -13,8 +13,8 @@ class YamlCommentDumperTest {
 
     @Test
     void dump() throws IOException {
-        final StringReader reader = new StringReader("test: 'test'\n" +
-            "test-2: 'test-2'");
+        final String content = "test: 'test'\n" + "test-2: 'test-2'\n" + "test-3: 'test-3 # hashtag'\n";
+        final StringReader reader = new StringReader(content);
         final YamlConfiguration configuration = new YamlConfiguration();
         final YamlConfigurationOptions options = new TestYamlConfigurationOptions(configuration);
         final YamlCommentMapper mapper = new YamlCommentMapper(options);
@@ -22,6 +22,8 @@ class YamlCommentDumperTest {
         mapper.setComment("test", "test comment", CommentType.SIDE);
         mapper.setComment("test-2", "test comment");
         mapper.setComment("test-2", "test comment", CommentType.SIDE);
+        mapper.setComment("test-3", "test # comment");
+        mapper.setComment("test-3", "test # comment", CommentType.SIDE);
         final YamlCommentDumper dumper = new YamlCommentDumper(options, mapper, reader);
 
         MatcherAssert.assertThat(
@@ -30,7 +32,9 @@ class YamlCommentDumperTest {
             new IsEqual<>("# test comment\n" +
                 "test: 'test' # test comment\n" +
                 "# test comment\n" +
-                "test-2: 'test-2' # test comment\n")
+                "test-2: 'test-2' # test comment\n" +
+                "# test # comment\n" +
+                "test-3: 'test-3 # hashtag' # test # comment\n")
         );
     }
 

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentDumperTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentDumperTest.java
@@ -13,7 +13,7 @@ class YamlCommentDumperTest {
 
     @Test
     void dump() throws IOException {
-        final String content = "test: 'test'\n" + "test-2: 'test-2'\n" + "test-3: 'test-3 # hashtag'\n";
+        final String content = "test: 'test'\n" + "test-2: 'test-2'\n" + "test-3: 'test-3 #'\n";
         final StringReader reader = new StringReader(content);
         final YamlConfiguration configuration = new YamlConfiguration();
         final YamlConfigurationOptions options = new TestYamlConfigurationOptions(configuration);
@@ -24,7 +24,7 @@ class YamlCommentDumperTest {
         mapper.setComment("test-2", "test comment", CommentType.SIDE);
         mapper.setComment("test-3", "test # comment");
         mapper.setComment("test-3", "test # comment", CommentType.SIDE);
-        final YamlCommentDumper dumper = new YamlCommentDumper(options, mapper, reader);
+        final YamlCommentDumper dumper = new YamlCommentDumper(mapper, reader);
 
         MatcherAssert.assertThat(
             "Comments are wrong!",
@@ -34,64 +34,39 @@ class YamlCommentDumperTest {
                 "# test comment\n" +
                 "test-2: 'test-2' # test comment\n" +
                 "# test # comment\n" +
-                "test-3: 'test-3 # hashtag' # test # comment\n")
+                "test-3: 'test-3 #' # test # comment\n")
         );
     }
 
     @Test
     void getNode() {
-        final StringReader reader = new StringReader("test: 'test'\n" +
-            "test-2: 'test-2'");
+        final StringReader reader = new StringReader("test: 'test'");
         final YamlConfiguration configuration = new YamlConfiguration();
         final YamlConfigurationOptions options = new TestYamlConfigurationOptions(configuration);
         final YamlCommentMapper mapper = new YamlCommentMapper(options);
         mapper.setComment("test", "test comment");
         mapper.setComment("test", "test comment", CommentType.SIDE);
-        mapper.setComment("test-2", "test comment");
-        mapper.setComment("test-2", "test comment", CommentType.SIDE);
-        final YamlCommentDumper dumper = new YamlCommentDumper(options, mapper, reader);
-        final KeyTree.Node testnode = dumper.getNode("test");
-        final KeyTree.Node test2node = dumper.getNode("test-2");
+        final YamlCommentDumper dumper = new YamlCommentDumper(mapper, reader);
+        final KeyTree.Node testNode = dumper.getNode("test");
 
         MatcherAssert.assertThat(
             "The indention is not 0!",
-            testnode.getIndentation(),
+            testNode.getIndentation(),
             new IsEqual<>(0)
         );
         MatcherAssert.assertThat(
             "The node name is not correct!",
-            testnode.getName(),
+            testNode.getName(),
             new IsEqual<>("test")
         );
         MatcherAssert.assertThat(
             "The comment's node is wrong",
-            testnode.getComment(),
-            new IsEqual<>("# test comment\n")
+            testNode.getComment(),
+            new IsEqual<>("# test comment")
         );
         MatcherAssert.assertThat(
             "The side comment's node is wrong",
-            testnode.getSideComment(),
-            new IsEqual<>(" # test comment")
-        );
-
-        MatcherAssert.assertThat(
-            "The indention is not 0!",
-            test2node.getIndentation(),
-            new IsEqual<>(0)
-        );
-        MatcherAssert.assertThat(
-            "The node name is not correct!",
-            test2node.getName(),
-            new IsEqual<>("test-2")
-        );
-        MatcherAssert.assertThat(
-            "The Comment's node is wrong",
-            test2node.getComment(),
-            new IsEqual<>("# test comment\n")
-        );
-        MatcherAssert.assertThat(
-            "The side comment's node is wrong",
-            test2node.getSideComment(),
+            testNode.getSideComment(),
             new IsEqual<>(" # test comment")
         );
     }

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentMapperTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentMapperTest.java
@@ -16,12 +16,12 @@ final class YamlCommentMapperTest {
         final YamlConfiguration configuration = new YamlConfiguration();
         final YamlConfigurationOptions options = new TestYamlConfigurationOptions(configuration);
         final YamlCommentMapper mapper = new YamlCommentMapper(options);
-        final String test_comment = "test comment";
+        final String test_comment = "test comment # hashtag";
         mapper.setComment("test", test_comment);
-        final String test_side_comment = "test side comment";
+        final String test_side_comment = "test side comment # hashtag";
         mapper.setComment("test", test_side_comment, CommentType.SIDE);
         final String comment = mapper.getComment("test");
-        final String sidecomment = mapper.getComment("test", CommentType.SIDE);
+        final String sideComment = mapper.getComment("test", CommentType.SIDE);
 
         MatcherAssert.assertThat(
             "Comment couldn't set!",
@@ -30,7 +30,7 @@ final class YamlCommentMapperTest {
         );
         MatcherAssert.assertThat(
             "Side comment couldn't set!",
-            sidecomment,
+            sideComment,
             new IsEqual<>(test_side_comment)
         );
     }
@@ -59,12 +59,12 @@ final class YamlCommentMapperTest {
         final YamlConfiguration configuration = new YamlConfiguration();
         final YamlConfigurationOptions options = new TestYamlConfigurationOptions(configuration);
         final YamlCommentMapper mapper = new YamlCommentMapper(options);
-        final String test_comment = "test_comment";
-        final String test_side_comment = "test_side_comment";
-        final String nodename = "test";
-        mapper.setComment(nodename, test_comment);
-        mapper.setComment(nodename, test_side_comment, CommentType.SIDE);
-        final KeyTree.Node node = mapper.getNode(nodename);
+        final String test_comment = "test comment # hashtag";
+        final String test_side_comment = "test side comment # hashtag";
+        final String nodeName = "test";
+        mapper.setComment(nodeName, test_comment);
+        mapper.setComment(nodeName, test_side_comment, CommentType.SIDE);
+        final KeyTree.Node node = mapper.getNode(nodeName);
 
         MatcherAssert.assertThat(
             "There is no node!",
@@ -84,7 +84,7 @@ final class YamlCommentMapperTest {
         MatcherAssert.assertThat(
             "The node name is not test!",
             node.getName(),
-            new IsEqual<>(nodename)
+            new IsEqual<>(nodeName)
         );
     }
 

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentMapperTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentMapperTest.java
@@ -16,22 +16,47 @@ final class YamlCommentMapperTest {
         final YamlConfiguration configuration = new YamlConfiguration();
         final YamlConfigurationOptions options = new TestYamlConfigurationOptions(configuration);
         final YamlCommentMapper mapper = new YamlCommentMapper(options);
-        final String test_comment = "test comment # hashtag";
-        mapper.setComment("test", test_comment);
-        final String test_side_comment = "test side comment # hashtag";
-        mapper.setComment("test", test_side_comment, CommentType.SIDE);
-        final String comment = mapper.getComment("test");
-        final String sideComment = mapper.getComment("test", CommentType.SIDE);
+
+        final String key = "test";
+
+        final String testComment = "test # comment";
+        mapper.setComment(key, testComment);
+
+        final String testSideComment = "test # side comment";
+        mapper.setComment(key, testSideComment, CommentType.SIDE);
+
+        final KeyTree.Node node = mapper.getNode(key);
 
         MatcherAssert.assertThat(
-            "Comment couldn't set!",
-            comment,
-            new IsEqual<>(test_comment)
+                "There is no node!",
+                node,
+                new IsNot<>(new IsNull<>())
         );
         MatcherAssert.assertThat(
-            "Side comment couldn't set!",
-            sideComment,
-            new IsEqual<>(test_side_comment)
+                "The node name is not test!",
+                node.getName(),
+                new IsEqual<>(key)
+        );
+        MatcherAssert.assertThat(
+                "Wrong node comment!",
+                node.getComment(),
+                new IsEqual<>("# " + testComment)
+        );
+        MatcherAssert.assertThat(
+                "Wrong node side comment!",
+                node.getSideComment(),
+                new IsEqual<>(" # " + testSideComment)
+        );
+
+        MatcherAssert.assertThat(
+                "Comment couldn't set!",
+                mapper.getComment(key),
+                new IsEqual<>(testComment)
+        );
+        MatcherAssert.assertThat(
+                "Side comment couldn't set!",
+                mapper.getComment(key, CommentType.SIDE),
+                new IsEqual<>(testSideComment)
         );
     }
 
@@ -46,45 +71,18 @@ final class YamlCommentMapperTest {
             mapper.getComment("test"),
             new IsNull<>()
         );
-        mapper.setComment("test", "test_comment");
+
+        mapper.setComment("test", "test # comment");
+
         MatcherAssert.assertThat(
-            "There is a comment on test path",
+            "Wrong comment",
             mapper.getComment("test"),
-            new IsNot<>(new IsNull<>())
-        );
-    }
-
-    @Test
-    void getNode() {
-        final YamlConfiguration configuration = new YamlConfiguration();
-        final YamlConfigurationOptions options = new TestYamlConfigurationOptions(configuration);
-        final YamlCommentMapper mapper = new YamlCommentMapper(options);
-        final String test_comment = "test comment # hashtag";
-        final String test_side_comment = "test side comment # hashtag";
-        final String nodeName = "test";
-        mapper.setComment(nodeName, test_comment);
-        mapper.setComment(nodeName, test_side_comment, CommentType.SIDE);
-        final KeyTree.Node node = mapper.getNode(nodeName);
-
-        MatcherAssert.assertThat(
-            "There is no node!",
-            node,
-            new IsNot<>(new IsNull<>())
+            new IsEqual<>("test # comment")
         );
         MatcherAssert.assertThat(
-            "There is no comment on the node!",
-            node.getComment(),
-            new IsEqual<>("# " + test_comment + '\n')
-        );
-        MatcherAssert.assertThat(
-            "There is no side comment near the node!",
-            node.getSideComment(),
-            new IsEqual<>(" # " + test_side_comment)
-        );
-        MatcherAssert.assertThat(
-            "The node name is not test!",
-            node.getName(),
-            new IsEqual<>(nodeName)
+                "Wrong node comment",
+                mapper.getNode("test").getComment(),
+                new IsEqual<>("# test # comment")
         );
     }
 

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentParserTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentParserTest.java
@@ -2,6 +2,9 @@ package org.simpleyaml.configuration.comments;
 
 import java.io.IOException;
 import java.io.StringReader;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.simpleyaml.configuration.file.YamlConfiguration;
 import org.simpleyaml.configuration.file.YamlConfigurationOptions;
@@ -11,13 +14,46 @@ final class YamlCommentParserTest {
 
     @Test
     void parse() throws IOException {
-        final StringReader reader = new StringReader("# test comment\n" +
-            "test: 'test' # test side comment \n" +
-            "# test comment 2");
+        final StringReader reader = new StringReader(YamlCommentReaderTest.COMMENT);
         final YamlConfiguration configuration = new YamlConfiguration();
         final YamlConfigurationOptions options = new TestYamlConfigurationOptions(configuration);
+
         final YamlCommentParser parser = new YamlCommentParser(options, reader);
         parser.parse();
+
+        MatcherAssert.assertThat(
+                "Comments are wrong!",
+                parser.getComment("test"),
+                new IsEqual<>("test comment")
+        );
+        MatcherAssert.assertThat(
+                "Comments are wrong!",
+                parser.getComment("test-section"),
+                new IsEqual<>("test-section # comment # hashtag")
+        );
+        MatcherAssert.assertThat(
+                "Comments are wrong!",
+                parser.getComment("test-section", CommentType.SIDE),
+                new IsEqual<>("comment # hashtag")
+        );
+        MatcherAssert.assertThat(
+                "Comments are wrong!",
+                parser.getComment("test-section.test", CommentType.SIDE),
+                new IsEqual<>("comment # hashtag")
+        );
+        MatcherAssert.assertThat(
+                "Parsed value is wrong!",
+                parser.getComment("test-section # hashtag.test", CommentType.SIDE),
+                new IsEqual<>("test # hashtag")
+        );
+
+        final YamlCommentDumper dumper = new YamlCommentDumper(options, parser, new StringReader(YamlCommentReaderTest.COMMENT));
+
+        MatcherAssert.assertThat(
+                "Comments are wrong!",
+                dumper.dump(),
+                new IsEqual<>(YamlCommentReaderTest.COMMENT)
+        );
     }
 
 }

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentParserTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentParserTest.java
@@ -65,6 +65,8 @@ final class YamlCommentParserTest {
                 parser.getComment("test-section"),
                 new IsEqual<>("\ntest-section # comment # character\n  - multiline comment # character ")
         );
+
+        YamlCommentFormat.reset();
     }
 
 }

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentParserTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentParserTest.java
@@ -1,14 +1,14 @@
 package org.simpleyaml.configuration.comments;
 
-import java.io.IOException;
-import java.io.StringReader;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.Test;
 import org.simpleyaml.configuration.file.YamlConfiguration;
 import org.simpleyaml.configuration.file.YamlConfigurationOptions;
-import org.simpleyaml.obj.TestYamlConfigurationOptions;
+
+import java.io.IOException;
+import java.io.StringReader;
 
 final class YamlCommentParserTest {
 
@@ -16,7 +16,7 @@ final class YamlCommentParserTest {
     void parse() throws IOException {
         final StringReader reader = new StringReader(YamlCommentReaderTest.COMMENT);
         final YamlConfiguration configuration = new YamlConfiguration();
-        final YamlConfigurationOptions options = new TestYamlConfigurationOptions(configuration);
+        final YamlConfigurationOptions options = configuration.options();
 
         final YamlCommentParser parser = new YamlCommentParser(options, reader);
         parser.parse();
@@ -67,6 +67,21 @@ final class YamlCommentParserTest {
         );
 
         YamlCommentFormat.reset();
+    }
+
+    @Test
+    void parseTag() throws IOException {
+        final StringReader reader = new StringReader("tag: !!comment ' # not a comment'\n");
+        final YamlConfiguration configuration = new YamlConfiguration();
+
+        final YamlCommentParser parser = new YamlCommentParser(configuration.options(), reader);
+        parser.parse();
+
+        MatcherAssert.assertThat(
+                "Comments are wrong!",
+                parser.getComment("tag", CommentType.SIDE),
+                new IsNull<>()
+        );
     }
 
 }

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentParserTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentParserTest.java
@@ -23,36 +23,47 @@ final class YamlCommentParserTest {
 
         MatcherAssert.assertThat(
                 "Comments are wrong!",
-                parser.getComment("test"),
+                parser.getComment("te'st"),
                 new IsEqual<>("test comment")
         );
         MatcherAssert.assertThat(
                 "Comments are wrong!",
                 parser.getComment("test-section"),
-                new IsEqual<>("test-section # comment # hashtag")
+                new IsEqual<>("test-section # comment # character\n  - multiline comment # character")
         );
         MatcherAssert.assertThat(
                 "Comments are wrong!",
                 parser.getComment("test-section", CommentType.SIDE),
-                new IsEqual<>("comment # hashtag")
+                new IsEqual<>("comment # character")
         );
         MatcherAssert.assertThat(
                 "Comments are wrong!",
                 parser.getComment("test-section.test", CommentType.SIDE),
-                new IsEqual<>("comment # hashtag")
-        );
-        MatcherAssert.assertThat(
-                "Parsed value is wrong!",
-                parser.getComment("test-section # hashtag.test", CommentType.SIDE),
-                new IsEqual<>("test # hashtag")
+                new IsEqual<>("comment # character")
         );
 
-        final YamlCommentDumper dumper = new YamlCommentDumper(options, parser, new StringReader(YamlCommentReaderTest.COMMENT));
+        options.commentFormatter().stripPrefix(false);
 
         MatcherAssert.assertThat(
                 "Comments are wrong!",
-                dumper.dump(),
-                new IsEqual<>(YamlCommentReaderTest.COMMENT)
+                parser.getComment("test-section"),
+                new IsEqual<>("# test-section # comment # character\n#   - multiline comment # character")
+        );
+
+        options.commentFormatter().trim(false);
+
+        MatcherAssert.assertThat(
+                "Comments are wrong!",
+                parser.getComment("test-section"),
+                new IsEqual<>("\n# test-section # comment # character\n#   - multiline comment # character ")
+        );
+
+        options.commentFormatter().stripPrefix(true);
+
+        MatcherAssert.assertThat(
+                "Comments are wrong!",
+                parser.getComment("test-section"),
+                new IsEqual<>("\ntest-section # comment # character\n  - multiline comment # character ")
         );
     }
 

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentReaderTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentReaderTest.java
@@ -14,11 +14,11 @@ import org.simpleyaml.obj.TestYamlConfigurationOptions;
 
 final class YamlCommentReaderTest {
 
-    private static final String COMMENT = "#test comment\n" +
+    static final String COMMENT = "#test comment\n" +
         "test: 'test'\n" +
-        "# test-section comment\n" +
-        "test-section:\n" +
-        "  test: 'test'";
+        "# test-section # comment # hashtag\n" +
+        "test-section: # comment # hashtag\n" +
+        "  test: 'test # hashtag' # comment # hashtag";
 
     @Test
     void isBlank() throws IOException {
@@ -46,7 +46,7 @@ final class YamlCommentReaderTest {
         final boolean comment = commentReader.isComment();
 
         MatcherAssert.assertThat(
-            "The tex is not a comment!",
+            "The text is not a comment!",
             comment,
             new IsTrue()
         );

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentReaderTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/comments/YamlCommentReaderTest.java
@@ -15,10 +15,11 @@ import org.simpleyaml.obj.TestYamlConfigurationOptions;
 final class YamlCommentReaderTest {
 
     static final String COMMENT = "#test comment\n" +
-        "test: 'test'\n" +
-        "# test-section # comment # hashtag\n" +
-        "test-section: # comment # hashtag\n" +
-        "  test: 'test # hashtag' # comment # hashtag";
+        "'te''st': 'test'\n\n" +
+        "# test-section # comment # character\n" +
+        "#   - multiline comment # character \n" +
+        "test-section: # comment # character\n" +
+        "  test: 'test # character' # comment # character\n";
 
     @Test
     void isBlank() throws IOException {
@@ -27,12 +28,20 @@ final class YamlCommentReaderTest {
         final YamlConfigurationOptions options = new TestYamlConfigurationOptions(configuration);
         final YamlCommentReader commentReader = new YamlCommentReader(options, reader);
         commentReader.nextLine();
-        final boolean blank = commentReader.isBlank();
 
         MatcherAssert.assertThat(
             "The text is blank!",
-            blank,
+            commentReader.isBlank(),
             new IsNot<>(new IsTrue())
+        );
+
+        commentReader.nextLine();
+        commentReader.nextLine();
+
+        MatcherAssert.assertThat(
+            "The text is not blank!",
+            commentReader.isBlank(),
+            new IsTrue()
         );
     }
 
@@ -74,17 +83,17 @@ final class YamlCommentReaderTest {
         final YamlConfigurationOptions options = new TestYamlConfigurationOptions(configuration);
         final YamlCommentReader commentReader = new YamlCommentReader(options, reader);
         commentReader.nextLine();
-        final KeyTree.Node track = commentReader.track();
+        final KeyTree.Node track = commentReader.track(0, "a");
 
         MatcherAssert.assertThat(
-            "The node has a root!",
+            "Wrong indentation!",
             track.getIndentation(),
             new IsEqual<>(0)
         );
         MatcherAssert.assertThat(
             "The node's name is not correct!",
             track.getName(),
-            new IsNull<>()
+            new IsEqual<>("a")
         );
         MatcherAssert.assertThat(
             "There is a comment!",

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlConfigurationOptionsTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlConfigurationOptionsTest.java
@@ -1,11 +1,15 @@
 package org.simpleyaml.configuration.file;
 
-import java.nio.charset.StandardCharsets;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.IsTrue;
+import org.llorllale.cactoos.matchers.Throws;
+import org.simpleyaml.configuration.comments.CommentType;
+import org.simpleyaml.configuration.comments.YamlCommentFormatterConfiguration;
+
+import java.nio.charset.StandardCharsets;
 
 class YamlConfigurationOptionsTest {
 
@@ -130,6 +134,68 @@ class YamlConfigurationOptionsTest {
                 "List indent has not changed!",
                 options.indentList(),
                 new IsEqual<>(0)
+        );
+    }
+
+    @Test
+    void commentFormatter() {
+        final YamlConfiguration configuration = new YamlConfiguration();
+        final YamlConfigurationOptions options = new YamlConfigurationOptions(configuration);
+
+        final YamlCommentFormatterConfiguration blockFormatterConfiguration = options.commentFormatter().formatterConfiguration(CommentType.BLOCK);
+
+        MatcherAssert.assertThat(
+                "Default comment prefix is not '# '!",
+                blockFormatterConfiguration.prefixFirst(),
+                new IsEqual<>("# ")
+        );
+
+        blockFormatterConfiguration.prefix("#");
+
+        MatcherAssert.assertThat(
+                "Comment prefix has not changed!",
+                blockFormatterConfiguration.prefixFirst(),
+                new IsEqual<>("#")
+        );
+
+        blockFormatterConfiguration.prefix("\n# ");
+
+        MatcherAssert.assertThat(
+                "Comment prefix has not changed!",
+                blockFormatterConfiguration.prefixFirst(),
+                new IsEqual<>("\n# ")
+        );
+
+        final YamlCommentFormatterConfiguration sideFormatterConfiguration = options.commentFormatter().formatterConfiguration(CommentType.SIDE);
+
+        MatcherAssert.assertThat(
+                "Default side comment prefix is not ' # '!",
+                sideFormatterConfiguration.prefixFirst(),
+                new IsEqual<>(" # ")
+        );
+
+        MatcherAssert.assertThat(
+                "Side comment must start with space",
+                () -> sideFormatterConfiguration.prefix("#"),
+                new Throws<>(IllegalArgumentException.class)
+        );
+
+        MatcherAssert.assertThat(
+                "Side comment prefix is invalid!",
+                sideFormatterConfiguration.prefixFirst(),
+                new IsNot<>(new IsEqual<>("#"))
+        );
+
+        MatcherAssert.assertThat(
+                "Side below comments should not require to start with a space",
+                () -> sideFormatterConfiguration.prefix("\n# "),
+                new IsNot<>(new Throws<>(IllegalArgumentException.class))
+        );
+
+        MatcherAssert.assertThat(
+                "Side comment prefix has not changed!",
+                sideFormatterConfiguration.prefixFirst(),
+                new IsEqual<>("\n# ")
         );
     }
 

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlConfigurationOptionsTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlConfigurationOptionsTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.IsTrue;
 import org.llorllale.cactoos.matchers.Throws;
 import org.simpleyaml.configuration.comments.CommentType;
+import org.simpleyaml.configuration.comments.YamlCommentFormat;
 import org.simpleyaml.configuration.comments.YamlCommentFormatterConfiguration;
 
 import java.nio.charset.StandardCharsets;
@@ -197,6 +198,8 @@ class YamlConfigurationOptionsTest {
                 sideFormatterConfiguration.prefixFirst(),
                 new IsEqual<>("\n# ")
         );
+
+        YamlCommentFormat.reset();
     }
 
     @Test

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlFileTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlFileTest.java
@@ -389,9 +389,27 @@ class YamlFileTest {
         );
 
         MatcherAssert.assertThat(
+                "Couldn't parse the comments correctly!",
+                yamlFile.getString("test.comment"),
+                new IsEqual<>("text with # hashtag")
+        );
+
+        MatcherAssert.assertThat(
+                "Couldn't parse the comments correctly!",
+                yamlFile.getComment("test.comment"),
+                new IsEqual<>("Block #comment with # hashtag")
+        );
+
+        MatcherAssert.assertThat(
             "Couldn't parse the side comments correctly!",
             yamlFile.getComment("test.list.entry", CommentType.SIDE),
             new IsEqual<>(":)")
+        );
+
+        MatcherAssert.assertThat(
+                "Couldn't parse the side comments correctly!",
+                yamlFile.getComment("test.comment", CommentType.SIDE),
+                new IsEqual<>("Side #comment with # hashtag")
         );
     }
 
@@ -399,13 +417,16 @@ class YamlFileTest {
     void setComment() throws Exception {
         final YamlFile yamlFile = new YamlFile(YamlFileTest.getResourceURI("test-comments.yml"));
         yamlFile.loadWithComments();
+
         yamlFile.setComment("test.string", "Edited hello comment!");
         yamlFile.setComment("test.string", "Edited hello side comment!", CommentType.SIDE);
+
         MatcherAssert.assertThat(
             "Couldn't parse the comments correctly!",
             yamlFile.getComment("test.string"),
             new IsEqual<>("Edited hello comment!")
         );
+
         MatcherAssert.assertThat(
             "Couldn't parse the comments correctly!",
             yamlFile.getComment("test.string", CommentType.SIDE),
@@ -623,6 +644,8 @@ class YamlFileTest {
                 "    - separated\n" +
                 "      # Comment on a list item\n" +
                 "    - entry # :)\n" +
+                "  # Block #comment with # hashtag\n" +
+                "  comment: 'text with # hashtag' # Side #comment with # hashtag\n" +
                 "\n" +
                 "# Wonderful number\n" +
                 "math:\n" +

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlFileTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlFileTest.java
@@ -17,6 +17,7 @@ import org.hamcrest.core.IsNot;
 import org.hamcrest.core.IsSame;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.IsTrue;
+import org.simpleyaml.configuration.ConfigurationSection;
 import org.simpleyaml.configuration.comments.CommentType;
 import org.simpleyaml.examples.Person;
 
@@ -291,8 +292,8 @@ class YamlFileTest {
         final String content = testComments();
 
         MatcherAssert.assertThat(
-            "Couldn't get the content of the file (toString)!",
-            yamlFile.toString(),
+            "Couldn't get the content of the file (saveToString)!",
+            yamlFile.saveToString(),
             new IsEqual<>(content));
     }
 
@@ -301,30 +302,11 @@ class YamlFileTest {
         final YamlFile yamlFile = new YamlFile(YamlFileTest.getResourceURI("test-comments2.yml"));
         yamlFile.loadWithComments();
 
-        final String content = "# Section\n" +
-            "section:\n" +
-            "  # Sub section\n" +
-            "  sub-section-1:\n" +
-            "    # List of numbers\n" +
-            "    list:\n" +
-            "      - 1\n" +
-            "      - 2\n" +
-            "      - 3\n" +
-            "  sub-section-2: # Side comment\n" +
-            "    list:\n" +
-            "      - 1\n" +
-            "      - 2 # Side comment on an arbitrary element\n" +
-            "      - 3\n" +
-            "  sub-section-3:\n" +
-            "    # List of numbers\n" +
-            "    list:        # Side comment with extra space\n" +
-            "      - 1\n" +
-            "      - 2\n" +
-            "      - 3\n";
+        final String content = yamlFile.fileToString();
 
         MatcherAssert.assertThat(
-            "Couldn't get the content of the file (toString)!",
-            yamlFile.toString(),
+            "Couldn't get the content of the file (saveToString)!",
+            yamlFile.saveToString(),
             new IsEqual<>(content));
     }
 
@@ -333,48 +315,25 @@ class YamlFileTest {
         final YamlFile yamlFile = new YamlFile(YamlFileTest.getResourceURI("test-comments3.yml"));
         yamlFile.loadWithComments();
 
-        final String content = "backup-config:\n" +
-            '\n' +
-            "  #######################################################################################################################\n" +
-            "  # SERVER-FILES BACKUP\n" +
-            "  #######################################################################################################################\n" +
-            '\n' +
-            "  # Backups your server.jar and all setting files before startup to /backups/server/...zip\n" +
-            "  server-files-backup:\n" +
-            "    enable: false\n" +
-            '\n' +
-            "    # Set max-days to 0 if you want to keep your server backups forever.\n" +
-            "    max-days: 7\n" +
-            '\n' +
-            '\n' +
-            "  #######################################################################################################################\n" +
-            "  # WORLDS BACKUP\n" +
-            "  #######################################################################################################################\n" +
-            '\n' +
-            "  # Backups all folders starting with \"world\" to /backups/worlds/...zip\n" +
-            "  worlds-backup:\n" +
-            "    enable: false\n" +
-            '\n' +
-            "    # Set max-days to 0 if you want to keep your world backups forever.\n" +
-            "    max-days: 7\n" +
-            '\n' +
-            '\n' +
-            "  #######################################################################################################################\n" +
-            "  # PLUGINS BACKUP\n" +
-            "  #######################################################################################################################\n" +
-            '\n' +
-            "  # Backups your plugins folder before startup to /backups/plugins/...zip\n" +
-            "  plugins-backup:\n" +
-            "    enable: true\n" +
-            '\n' +
-            "    # Set max-days to 0 if you want to keep your plugin backups forever.\n" +
-            "    max-days: 7\n" +
-            '\n';
+        final String content = yamlFile.fileToString();
 
         MatcherAssert.assertThat(
-            "Couldn't get the content of the file (toString)!",
-            yamlFile.toString(),
+            "Couldn't get the content of the file (saveToString)!",
+            yamlFile.saveToString(),
             new IsEqual<>(content));
+    }
+
+    @Test
+    void saveToStringWithComments4() throws Exception {
+        final YamlFile yamlFile = new YamlFile(YamlFileTest.getResourceURI("test-comments4.yml"));
+        yamlFile.loadWithComments();
+
+        final String content = testCommentsSpecial();
+
+        MatcherAssert.assertThat(
+                "Couldn't get the content of the file (saveToString)!",
+                yamlFile.saveToString(),
+                new IsEqual<>(content));
     }
 
     @Test
@@ -389,7 +348,7 @@ class YamlFileTest {
         );
 
         MatcherAssert.assertThat(
-                "Couldn't parse the comments correctly!",
+                "Couldn't parse the values correctly!",
                 yamlFile.getString("test.comment"),
                 new IsEqual<>("text with # hashtag")
         );
@@ -411,6 +370,19 @@ class YamlFileTest {
                 yamlFile.getComment("test.comment", CommentType.SIDE),
                 new IsEqual<>("Side #comment with # hashtag")
         );
+    }
+
+    @Test
+    void getComment2() throws Exception {
+        final YamlFile yamlFile = new YamlFile(YamlFileTest.getResourceURI("test-comments4.yml"));
+        yamlFile.loadWithComments();
+
+        yamlFile.getConfigurationSection("test").getKeys(false)
+                .forEach((key) ->
+                        MatcherAssert.assertThat(
+                                "Side comment mismatch (test." + key + ")",
+                                yamlFile.getComment("test." + key, CommentType.SIDE),
+                                new IsEqual<>("Side #comment with \"#\" character")));
     }
 
     @Test
@@ -661,6 +633,23 @@ class YamlFileTest {
                 "  formattedDate: 04/07/2020 15:18:04\n" +
                 "\n" +
                 "# End\n";
+    }
+
+    private static String testCommentsSpecial() {
+        return "#####################\n" +
+                "## INITIAL COMMENT ##\n" +
+                "#####################\n" +
+                "\n" +
+                "# Test comments\n" +
+                "test:\n" +
+                "  # Block #comment with \"#\" character\n" +
+                "  single: 'text with # character' # Side #comment with \"#\" character\n" +
+                "  double: 'text with # character' # Side #comment with \"#\" character\n" +
+                "  escape: text with \"#\" character \\\" # Side #comment with \"#\" character\n" +
+                "  escape2: text with '#' character \\\" # Side #comment with \"#\" character\n" +
+                "  special: 'This is a string ''''with a # character \"inside of it' # Side #comment with \"#\" character\n" +
+                "  multiline: 'This is a string\" \" which got ''''wrapped and also contains a # in its\n" +
+                "    ''''content.' # Side #comment with \"#\" character\n";
     }
 
 }

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlFileTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlFileTest.java
@@ -619,6 +619,7 @@ class YamlFileTest {
                 "    - a\n" +
                 "    - separated\n" +
                 "    - entry\n" +
+                "  comment: 'text with # hashtag'\n" +
                 "math:\n" +
                 "  pi: 3.141592653589793\n" +
                 "timestamp:\n" +

--- a/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlFileTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/configuration/file/YamlFileTest.java
@@ -350,6 +350,36 @@ class YamlFileTest {
                 yamlFile.getComment("test.wrap", CommentType.SIDE),
                 new IsNull<>()
         );
+
+        MatcherAssert.assertThat(
+                "Couldn't parse the comments correctly!",
+                yamlFile.getComment("math", YamlCommentFormat.RAW),
+                new IsEqual<>("\n# Wonderful numbers")
+        );
+
+        MatcherAssert.assertThat(
+                "Couldn't parse the side comments below correctly!",
+                yamlFile.getComment("math.pi", CommentType.SIDE),
+                new IsEqual<>("Side comment below")
+        );
+
+        MatcherAssert.assertThat(
+                "Couldn't parse the side comments below correctly!",
+                yamlFile.getComment("math.pi", CommentType.SIDE, YamlCommentFormat.RAW),
+                new IsEqual<>("\n# Side comment below")
+        );
+
+        MatcherAssert.assertThat(
+                "Couldn't parse the comments correctly!",
+                yamlFile.getComment("timestamp"),
+                new IsEqual<>("Some timestamps")
+        );
+
+        MatcherAssert.assertThat(
+                "Couldn't parse the comments correctly!",
+                yamlFile.getComment("timestamp", YamlCommentFormat.RAW),
+                new IsEqual<>("\n# Some timestamps")
+        );
     }
 
     @Test

--- a/Simple-Yaml/src/test/java/org/simpleyaml/examples/Person.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/examples/Person.java
@@ -12,7 +12,7 @@ import org.simpleyaml.configuration.serialization.ConfigurationSerializable;
  */
 public class Person implements ConfigurationSerializable {
 
-    private final String dni;
+    private final String id;
 
     private final String name;
 
@@ -20,15 +20,15 @@ public class Person implements ConfigurationSerializable {
 
     private boolean isAlive;
 
-    public Person(final String dni, final String name, final int birthYear, final boolean isAlive) {
-        this.dni = dni;
+    public Person(final String id, final String name, final int birthYear, final boolean isAlive) {
+        this.id = id;
         this.name = name;
         this.birthYear = birthYear;
         this.isAlive = isAlive;
     }
 
-    public Person(final String dni, final String name, final int birthYear) {
-        this(dni, name, birthYear, true);
+    public Person(final String id, final String name, final int birthYear) {
+        this(id, name, birthYear, true);
     }
 
     /*
@@ -40,7 +40,7 @@ public class Person implements ConfigurationSerializable {
      */
 
     public static Person deserialize(final Map<String, Object> mappedObject) { // note that is static
-        return new Person((String) mappedObject.get("dni"),
+        return new Person((String) mappedObject.get("id"),
             (String) mappedObject.get("name"),
             (int) mappedObject.get("birthYear"),
             (boolean) mappedObject.get("isAlive"));
@@ -48,16 +48,16 @@ public class Person implements ConfigurationSerializable {
 
     @Override
     public Map<String, Object> serialize() {
-        final Map<String, Object> mappedObject = new LinkedHashMap<String, Object>();
-        mappedObject.put("dni", this.dni);
+        final Map<String, Object> mappedObject = new LinkedHashMap<>();
+        mappedObject.put("id", this.id);
         mappedObject.put("name", this.name);
         mappedObject.put("birthYear", this.birthYear);
         mappedObject.put("isAlive", this.isAlive);
         return mappedObject;
     }
 
-    public String getDni() {
-        return this.dni;
+    public String getId() {
+        return this.id;
     }
 
     public String getName() {
@@ -78,7 +78,7 @@ public class Person implements ConfigurationSerializable {
 
     @Override
     public String toString() {
-        return "Person [dni= " + this.dni + ", name= " + this.name + ", birthYear= " + this.birthYear + ", isAlive= " + this.isAlive + "]";
+        return "Person [id= " + this.id + ", name= " + this.name + ", birthYear= " + this.birthYear + ", isAlive= " + this.isAlive + "]";
     }
 
 }

--- a/Simple-Yaml/src/test/java/org/simpleyaml/examples/YamlCommentsExample.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/examples/YamlCommentsExample.java
@@ -1,56 +1,160 @@
 package org.simpleyaml.examples;
 
 import org.simpleyaml.configuration.comments.CommentType;
+import org.simpleyaml.configuration.comments.YamlCommentFormat;
 import org.simpleyaml.configuration.file.YamlFile;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
 
 /**
- * This class shows you how to use this API to load and save a YAML file with comments.
+ * This example shows you how to use this API to load and save a YAML file with comments.
  *
  * @author Carlos Lazaro Costa
  */
 public final class YamlCommentsExample {
 
-    public static void main(final String[] args) throws Exception {
-        // Create new YAML file
-        final YamlFile yamlFile = new YamlFile(getResource("test-comments.yml"));
+    public static void main(final String[] args) throws IOException {
+        // Create new YAML file with relative path
+        final YamlFile yamlFile = new YamlFile("examples/test-comments.yml");
 
         System.out.println(yamlFile.getFilePath());
 
-        // Load the YAML file if it is already created
-        if (yamlFile.exists()) {
-            yamlFile.loadWithComments();
-        } else {
-            throw new FileNotFoundException(yamlFile.getFilePath() + " does not exist");
-        }
+        // Load the YAML file if is already created or create new one otherwise
+        yamlFile.createOrLoadWithComments();
 
-        // Header
-        System.out.println(yamlFile.options().header());
+        // Set header format
 
-        // TODO Custom yamlFile.options().commentFormatter() configuration
+        // This is optional, the default header prefix is "# "
+        // Here we change the prefix and add some suffix to format the header.
+        yamlFile.options().headerFormatter()
+                .prefixFirst("######################")
+                .commentPrefix("##  ")
+                .commentSuffix("  ##")
+                .suffixLast("######################");
 
-        // Add some comments programmatically
-        yamlFile.setComment("test.string", "Hello!");
+        // Set header
+
+        yamlFile.setHeader("HEADER COMMENT"); // this header will be formatted using above header format and will have a blank line at the end
+
+        // Get header
+
+        System.out.println("Header without format: " + yamlFile.options().header()); // this returns the string you set above
+        System.out.println("Header with format:\n" + yamlFile.getHeader()); // this returns the header formatted
+
+        System.out.println("Copy header: " + yamlFile.options().copyHeader()); // true if header is going to be written to the file
+        System.out.print("Dump header:\n" + yamlFile.buildHeader()); // this returns how the header will be added to the file
+
+        /*
+          The difference between buildHeader() and getHeader() is that buildHeader() returns the header as it will be in the result file:
+          it will have a blank line at the end and it would be empty "" if copying the header is not desired: options().copyHeader(false)
+        */
+
+        // Add some default values
+        yamlFile.addDefault("test.number", 5);
+        yamlFile.addDefault("test.string", "Hello world");
+        yamlFile.addDefault("test.boolean", true);
+
+        // Set comments programmatically
+
+        yamlFile.setComment("test", "Test comments"); // The # prefix is not needed (it will be added automatically by the default comment format)
+        yamlFile.setComment("test.string", "# Hello!"); // But you can include it if you want (this overrides the default comment format)
+        yamlFile.setComment("test.list", "List of words");
+
+        // You can add values after setting a comment
+        yamlFile.set("test.list", Arrays.asList("Each word will be in a separated entry".split(" ")));
+
+        // You can add comments even on list values!
+        yamlFile.setComment("test.list.entry", "Comment on a list item");
+
+        // Side comments
         yamlFile.setComment("test.list.entry", ":)", CommentType.SIDE);
 
-        // Get comments programmatically
+        // Multiline comments
+        yamlFile.setComment("test.wrap", "This is a\nmultiline comment");
+        yamlFile.set("test.wrap", "# this is not a comment");
+
+        // Setting blank lines as a comment, in different ways
+        yamlFile.setComment("test.blank", "\n"); // Set \n as a block comment
+        yamlFile.setComment("test.blank", "", YamlCommentFormat.BLANK_LINE); // Use the BLANK_LINE comment format
+        yamlFile.setBlankLine("test.blank"); // Convenience method
+        yamlFile.path("test.blank").blankLine(); // Alternative API
+
+        yamlFile.set("test.blank", ""); // empty value (this is not a comment)
+        yamlFile.set("math.pi", Math.PI);
+
+        // Set default comment format
+
+        // This is optional, the default comment prefix is "# " without any blank lines above.
+        // Here we change the default comment format to add blank lines automatically on root keys so it is more readable.
+        yamlFile.setCommentFormat(YamlCommentFormat.PRETTY);
+
+        /*
+          The default comment format can be overridden in several ways:
+          - Changing the default comment format with setCommentFormat method
+          - Changing the comment format for a specific comment with setComment passing the comment format as the last argument
+          - Adding the # prefix by hand on every comment line at setComment
+            (if all comment lines are either \n or prefixed with # then the default comment format is ignored)
+         */
+
+        // With the PRETTY comment format a blank line will be added by default above the "math" key when setting a comment
+        yamlFile.setComment("math", "Wonderful numbers");
+        // Another way to add a blank line before a comment with the DEFAULT comment format (the default if PRETTY is not enabled)
+        yamlFile.setComment("math", "\n# Wonderful numbers", YamlCommentFormat.DEFAULT);
+        // Or using the BLANK_LINE comment format
+        yamlFile.setComment("math", "Wonderful numbers", YamlCommentFormat.BLANK_LINE);
+        // Or using the alternative API
+        yamlFile.path("math").comment("Wonderful numbers", YamlCommentFormat.BLANK_LINE);
+        yamlFile.path("math").comment("Wonderful numbers").blankLine();
+
+        // With side comments the BLANK_LINE comment format sets the side comment as a block comment below
+        yamlFile.setComment("math.pi", "Side comment below", CommentType.SIDE, YamlCommentFormat.BLANK_LINE);
+
+        final Date now = new Date();
+        final SimpleDateFormat df = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
+
+        // Alternative API for setting values along with comments
+        yamlFile.path("timestamp").comment("Some timestamps") // select the "timestamp" path and add a comment
+                .path("canonicalDate").set(now).comment("ISO") // select the "timestamp.canonicalDate" child path, set its value and add a comment
+                .parent() // go back to the "timestamp" path
+                .path("formattedDate").set(df.format(now)).comment("Date/Time with format").commentSide(df.toPattern());
+
+        // If a section or key does not exist then it will not be created when adding a comment to that path
+        yamlFile.setComment("unknown", "This comment will not be written to the file");
+
+        // Get comments
+
+        // The DEFAULT or PRETTY comment formatters will return a clean comment using getComment, without # prefix nor blank lines
         System.out.println(
             yamlFile.getComment("test.string") + " " + yamlFile.getComment("test.list.entry", CommentType.SIDE)
         );
 
-        // Save the file!
-        try {
-            yamlFile.save();
-        } catch (final IOException e) {
-            e.printStackTrace();
-        }
-    }
+        // The RAW comment formatter will return the comments with the # prefix and blank lines using getComment
+        yamlFile.setCommentFormat(YamlCommentFormat.RAW);
 
-    private static URL getResource(final String file) {
-        return YamlCommentsExample.class.getClassLoader().getResource(file);
+        System.out.println(
+                yamlFile.getComment("test.wrap")
+        );
+
+        System.out.println(
+                yamlFile.getComment("test.wrap", YamlCommentFormat.PRETTY) // change the comment format only for a specific comment
+        );
+
+        System.out.println(
+                yamlFile.getComment("math") // Uses the RAW format set previously
+        );
+
+        yamlFile.setCommentFormat(YamlCommentFormat.PRETTY);
+
+        // Footer comment
+        yamlFile.setFooter("End"); // blank line will be added above the footer with the PRETTY comment format
+
+        System.out.println(yamlFile.getFooter()); // will use the comment format previously set
+
+        // Save the file!
+        yamlFile.save();
     }
 
 }

--- a/Simple-Yaml/src/test/java/org/simpleyaml/examples/YamlCommentsExample.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/examples/YamlCommentsExample.java
@@ -6,7 +6,6 @@ import org.simpleyaml.configuration.file.YamlFile;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Objects;
 
 /**
  * This class shows you how to use this API to load and save a YAML file with comments.
@@ -19,10 +18,19 @@ public final class YamlCommentsExample {
         // Create new YAML file
         final YamlFile yamlFile = new YamlFile(getResource("test-comments.yml"));
 
+        System.out.println(yamlFile.getFilePath());
+
         // Load the YAML file if it is already created
-        if (!yamlFile.exists()) {
+        if (yamlFile.exists()) {
+            yamlFile.loadWithComments();
+        } else {
             throw new FileNotFoundException(yamlFile.getFilePath() + " does not exist");
         }
+
+        // Header
+        System.out.println(yamlFile.options().header());
+
+        // TODO Custom yamlFile.options().commentFormatter() configuration
 
         // Add some comments programmatically
         yamlFile.setComment("test.string", "Hello!");
@@ -42,7 +50,7 @@ public final class YamlCommentsExample {
     }
 
     private static URL getResource(final String file) {
-        return Objects.requireNonNull(YamlCommentsExample.class.getClassLoader().getResource(file));
+        return YamlCommentsExample.class.getClassLoader().getResource(file);
     }
 
 }

--- a/Simple-Yaml/src/test/java/org/simpleyaml/examples/YamlExample.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/examples/YamlExample.java
@@ -10,7 +10,7 @@ import org.simpleyaml.configuration.file.YamlFile;
 
 /**
  * YAML is a human-readable data serialization language.<br>
- * This class shows you how to use this API to use these files to save your data.
+ * This example shows you how to use this API to use these files to save your data.
  *
  * @author Carlos Lazaro Costa
  */
@@ -40,17 +40,19 @@ public final class YamlExample {
         // You can manage hierarchies by separating the sections with a dot at path
         // Let's put some values to the file
 
+        // Defaults are added when they are not present in the file, otherwise the existing values will not be overwritten
         yamlFile.addDefault("test.number", 5);
         yamlFile.addDefault("test.string", "Hello world");
         yamlFile.addDefault("test.boolean", true);
 
+        // Setting values overwrites the value if there was any
         yamlFile.set("math.pi", Math.PI);
         yamlFile.set("math.e", Math.E);
 
         // More additions, e.g. adding entire lists
 
-        final List<String> list = Arrays.asList("Each word will be in a separated entry".split("\\s+"));
-        yamlFile.set("test.list", list);
+        final List<String> words = Arrays.asList("Each word will be in a separated entry".split(" "));
+        yamlFile.set("test.list", words);
 
         // You can move between sections with a ConfigurationSection
 
@@ -98,14 +100,17 @@ public final class YamlExample {
         // You can use many methods to obtain some types without casting (String, int, double...)
 
         final double pi = yamlFile.getDouble("math.pi");
-        System.out.println(pi);
+        System.out.println("PI: " + pi);
+
+        final List<String> list = yamlFile.getStringList("test.list");
+        System.out.println("List: " + list);
 
         // And you can also use methods with default values if the path is unknown
 
         final String value = yamlFile.getString("randomSection.noValue"); // returns null
         System.out.println(value);
 
-        final String defValue = yamlFile.getString("randomSection.noValue", "Default");
+        final String defValue = yamlFile.getString("randomSection.noValue", "Default"); // returns Default
         System.out.println(defValue);
 
         // Finally, save changes!

--- a/Simple-Yaml/src/test/java/org/simpleyaml/examples/YamlSerializationExample.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/examples/YamlSerializationExample.java
@@ -4,7 +4,7 @@ import org.simpleyaml.configuration.file.YamlFile;
 import org.simpleyaml.configuration.serialization.ConfigurationSerialization;
 
 /**
- * This class shows you how to use this API to serialize and deserialize Objects.
+ * This example shows you how to use this API to serialize and deserialize Objects.
  *
  * @author Carlos Lazaro Costa
  */
@@ -40,7 +40,7 @@ public final class YamlSerializationExample {
                 // Write an object to the YAML file
                 final Person p = new Person("12345678A", "John", 1990);
 
-                yamlFile.set("test.people." + p.getDni(), p);
+                yamlFile.set("test.people." + p.getId(), p);
 
                 // Don't forget to save the file!
                 yamlFile.save();

--- a/Simple-Yaml/src/test/java/org/simpleyaml/utils/StringUtilsTest.java
+++ b/Simple-Yaml/src/test/java/org/simpleyaml/utils/StringUtilsTest.java
@@ -1,0 +1,320 @@
+package org.simpleyaml.utils;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    void lines() {
+        MatcherAssert.assertThat(
+                StringUtils.lines("1\n2\n3\n\n"),
+                new IsEqual<>(new String[] { "1", "2", "3" })
+        );
+        MatcherAssert.assertThat(
+                StringUtils.lines("1\n2\n3\n\n", false),
+                new IsEqual<>(new String[] { "1", "2", "3", "", "" })
+        );
+        MatcherAssert.assertThat(
+                StringUtils.lines("\n1\n2\n3"),
+                new IsEqual<>(new String[] { "", "1", "2", "3" })
+        );
+        MatcherAssert.assertThat(
+                StringUtils.lines("1\n2\n3"),
+                new IsEqual<>(new String[] { "1", "2", "3" })
+        );
+        MatcherAssert.assertThat(
+                StringUtils.lines("1"),
+                new IsEqual<>(new String[] { "1" })
+        );
+        MatcherAssert.assertThat(
+                StringUtils.lines("\n"),
+                new IsEqual<>(new String[0])
+        );
+        MatcherAssert.assertThat(
+                StringUtils.lines("\n", false),
+                new IsEqual<>(new String[] { "", "" })
+        );
+    }
+
+    @Test
+    void indentation() {
+        MatcherAssert.assertThat(
+                StringUtils.indentation(5),
+                new IsEqual<>("     ")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.indentation(0),
+                new IsEqual<>("")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.indentation(-1),
+                new IsEqual<>("")
+        );
+    }
+
+    @Test
+    void padding() {
+        MatcherAssert.assertThat(
+                StringUtils.padding(5, '-'),
+                new IsEqual<>("-----")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.padding(0, '-'),
+                new IsEqual<>("")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.padding(-1, '-'),
+                new IsEqual<>("")
+        );
+    }
+
+    @Test
+    void stripIndentation() {
+        MatcherAssert.assertThat(
+                StringUtils.stripIndentation(" "),
+                new IsEqual<>("")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.stripIndentation("  Hi  "),
+                new IsEqual<>("Hi  ")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.stripIndentation("Hi"),
+                new IsEqual<>("Hi")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.stripIndentation(" 1 \n  2 "),
+                new IsEqual<>("1 \n2 ")
+        );
+    }
+
+    @Test
+    void stripPrefix() {
+        MatcherAssert.assertThat(
+                StringUtils.stripPrefix("# Comment", "# "),
+                new IsEqual<>("Comment")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.stripPrefix(" # Comment", "# "),
+                new IsEqual<>(" # Comment")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.stripPrefix("#Comment", "# "),
+                new IsEqual<>("#Comment")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.stripPrefix("#Comment", "# ", "#"),
+                new IsEqual<>("Comment")
+        );
+    }
+
+    @Test
+    void afterNewLine() {
+        MatcherAssert.assertThat(
+                StringUtils.afterNewLine("1\n2"),
+                new IsEqual<>("2")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.afterNewLine("\n2"),
+                new IsEqual<>("2")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.afterNewLine("1\n"),
+                new IsEqual<>("")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.afterNewLine("1"),
+                new IsEqual<>("")
+        );
+    }
+
+    @Test
+    void splitTrailingNewLines() {
+        MatcherAssert.assertThat(
+                StringUtils.splitTrailingNewLines(""),
+                new IsEqual<>(new String[] { "", "" })
+        );
+        MatcherAssert.assertThat(
+                StringUtils.splitTrailingNewLines("\n"),
+                new IsEqual<>(new String[] { "", "\n" })
+        );
+        MatcherAssert.assertThat(
+                StringUtils.splitTrailingNewLines("1\n2"),
+                new IsEqual<>(new String[] { "1\n2", "" })
+        );
+        MatcherAssert.assertThat(
+                StringUtils.splitTrailingNewLines("1\n"),
+                new IsEqual<>(new String[] { "1", "\n" })
+        );
+        MatcherAssert.assertThat(
+                StringUtils.splitTrailingNewLines("\n2"),
+                new IsEqual<>(new String[] { "\n2", "" })
+        );
+        MatcherAssert.assertThat(
+                StringUtils.splitTrailingNewLines("1\n2\n\n"),
+                new IsEqual<>(new String[] { "1\n2", "\n\n" })
+        );
+    }
+
+    @Test
+    void allLinesArePrefixed() {
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("", ""),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("#", ""),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("#", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("\t#\n  #\n# ", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("\t#\n  #\n \n", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed(" ", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("\n", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("\n\n", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("1", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("#\n", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("\n#\n", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("\n\n#\n", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("1\n#\n", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixed("#\n#\n 1", "#"),
+                new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    void allLinesArePrefixedOrBlank() {
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("", ""),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("#", ""),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("\n", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("#", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("#\n", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("\t#\n  #\n# ", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("\t#\n  #\n# \n", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("\t#\n  #\n \n", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank(" ", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("\n\n", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("1", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("\n#\n", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("\n\n#\n", "#"),
+                new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("1\n#\n", "#"),
+                new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+                StringUtils.allLinesArePrefixedOrBlank("#\n#\n 1", "#"),
+                new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    void quoteNewLines() {
+        MatcherAssert.assertThat(
+                StringUtils.quoteNewLines(""),
+                new IsEqual<>("")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.quoteNewLines("1"),
+                new IsEqual<>("1")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.quoteNewLines("\n"),
+                new IsEqual<>("\\n")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.quoteNewLines("\\n"),
+                new IsEqual<>("\\n")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.quoteNewLines("\n\n"),
+                new IsEqual<>("\\n\\n")
+        );
+        MatcherAssert.assertThat(
+                StringUtils.quoteNewLines("#\n#\n 1"),
+                new IsEqual<>("#\\n#\\n 1")
+        );
+    }
+}

--- a/Simple-Yaml/src/test/resources/test-comments.yml
+++ b/Simple-Yaml/src/test/resources/test-comments.yml
@@ -19,6 +19,8 @@ test:
     - separated
       # Comment on a list item
     - entry # :)
+  # Block #comment with # hashtag
+  comment: 'text with # hashtag' # Side #comment with # hashtag
 
 # Wonderful number
 math:

--- a/Simple-Yaml/src/test/resources/test-comments.yml
+++ b/Simple-Yaml/src/test/resources/test-comments.yml
@@ -1,6 +1,6 @@
-#####################
-## INITIAL COMMENT ##
-#####################
+######################
+##  HEADER COMMENT  ##
+######################
 
 # Test comments
 test:
@@ -19,8 +19,9 @@ test:
     - separated
       # Comment on a list item
     - entry # :)
-  # Block #comment with # hashtag
-  comment: 'text with # hashtag' # Side #comment with # hashtag
+  # This is a
+  # multiline comment
+  wrap: '# this is not a comment'
 
 # Wonderful number
 math:

--- a/Simple-Yaml/src/test/resources/test-comments.yml
+++ b/Simple-Yaml/src/test/resources/test-comments.yml
@@ -17,22 +17,24 @@ test:
     - in
     - a
     - separated
-      # Comment on a list item
+    # Comment on a list item
     - entry # :)
   # This is a
   # multiline comment
   wrap: '# this is not a comment'
 
-# Wonderful number
+  blank: ''
+
+# Wonderful numbers
 math:
   pi: 3.141592653589793
-  # Comment without direct key
+  # Side comment below
 
 # Some timestamps
 timestamp:
   # ISO
   canonicalDate: 2020-07-04T13:18:04.458Z
   # Date/Time with format
-  formattedDate: 04/07/2020 15:18:04
+  formattedDate: 04/07/2020 15:18:04 # dd/MM/yyyy HH:mm:ss
 
 # End

--- a/Simple-Yaml/src/test/resources/test-comments4.yml
+++ b/Simple-Yaml/src/test/resources/test-comments4.yml
@@ -1,0 +1,14 @@
+#####################
+## INITIAL COMMENT ##
+#####################
+
+# Test comments
+test:
+  # Block #comment with "#" character
+  single: 'text with # character' # Side #comment with "#" character
+  double: "text with # character" # Side #comment with "#" character
+  escape: "text with \"#\" character \\\"" # Side #comment with "#" character
+  escape2: 'text with ''#'' character \"' # Side #comment with "#" character
+  special: "This is a string ''with a # character \"inside of it" # Side #comment with "#" character
+  multiline: "This is a string\" \" which got ''wrapped and also contains a #
+   in its ''content." # Side #comment with "#" character

--- a/Simple-Yaml/src/test/resources/test-comments4.yml
+++ b/Simple-Yaml/src/test/resources/test-comments4.yml
@@ -1,14 +1,38 @@
-#####################
-## INITIAL COMMENT ##
-#####################
+######################
+##  HEADER COMMENT  ##
+######################
 
 # Test comments
 test:
-  # Block #comment with "#" character
-  single: 'text with # character' # Side #comment with "#" character
-  double: "text with # character" # Side #comment with "#" character
-  escape: "text with \"#\" character \\\"" # Side #comment with "#" character
-  escape2: 'text with ''#'' character \"' # Side #comment with "#" character
-  special: "This is a string ''with a # character \"inside of it" # Side #comment with "#" character
-  multiline: "This is a string\" \" which got ''wrapped and also contains a #
-   in its ''content." # Side #comment with "#" character
+  # Block #comment with # character
+  ' wrap ': " # not a comment "# Side #comment with # character
+  'single': 'text with # character' # Side #comment with # character
+  "double": "text with # character"  # Side #comment with # character
+  es'cape: "text with \"#\" character \\\"" # Side #comment with # character
+  es'cape2': 'text with ''#'' character \"' # Side #comment with # character
+  :es:cape3": "This is a string ''with a # character \"inside of it" # Side #comment with # character
+  -? escape4: -'# not a \#comment # Side #comment with # character
+  multiline: 'This is a string\" \" which got ''wrapped and also contains a     #
+  in its ''content.' # Side #comment with # character
+  multiline2: | # Side #comment with # character
+    'line one' # not a comment
+    line two # not a comment
+  # This is a'#
+  # multiline comment #~
+  special2: text"#"' # Side #comment with # character
+     # unexpected indentation comment but valid
+  special3: text'#''# not comment # Side #comment with # character
+  special4: text''#''# not comment # Side #comment with # character
+  entries: # Side #comment with # character
+    # Comment on a list item with # character
+    - entry'#'' #:)
+    # dangling comment
+  # Block #comment with # character
+
+  # Multiple line comment with blank line
+  comment: 'text with # character'# Side #comment with # character
+
+  # Multiple line comment
+  #  with blank line
+  blank: ''# Side #comment with # character
+  # Multiple line comment with blank line

--- a/Simple-Yaml/src/test/resources/test-map-list.yml
+++ b/Simple-Yaml/src/test/resources/test-map-list.yml
@@ -4,12 +4,12 @@ test:
   - 3
 people:
   - ==: org.simpleyaml.examples.Person
-    dni: 12345678A
+    id: 12345678A
     name: John
     birthYear: 1990
     isAlive: true
   - ==: org.simpleyaml.examples.Person
-    dni: 12345678B
+    id: 12345678B
     name: Maria
     birthYear: 1990
     isAlive: true


### PR DESCRIPTION
## Fixes #42 

The comment parser and dumper has been reworked. Previously it was breaking when using a comment prefix `#` inside quotes. Now it takes into account quotes and literals for plain, double quote or single quote scalar styles.

## Formatting comments #53 

Header behaviour has changed to be more intuitive. Now the header is considered to be the first block comment until a blank line (i.e. with no direct key below), instead of everything above the first key like before. The comment on the first key does not overlap anymore with the header. The header and the first key comment are separated by a blank line.

A footer shortcut has been added for the last comment of the file without any key below (null path).

In addition, now it would be possible to format comments using prefixes and suffixes, globally or per comment, taking into account blank lines as comments, with some configurations available for reading comments (for instance stripping the # prefix and stripping trailing or leading blank lines).

The default prefix is `"# "` for block comments and `" # "` for side comments. You can change them to add blank lines above or below the comments, or to add more spaces, # characters or section dividers.

Some default formatters are provided, for instance the following will add blank lines for the comments of root keys (those with indent 0):

```java
yamlFile.setCommentFormat(YamlCommentFormat.PRETTY);
```

### Alternative API

An alternative API has been added to set comments along with values without repeating the path. Example:

Normal API:
```java
yamlFile.set("test.hello", "Hello");
yamlFile.setComment("test.hello", "Block comment");
yamlFile.setComment("test.hello", "Side comment", CommentType.SIDE);
```
       
Alternative API:
```java
yamlFile.path("test.hello")
        .set("Hello")
        .comment("Block comment")
        .commentSide("Side comment");
```

This alternative is only available for setting values (or defaults) and comments. To read those values and comments you still need to use the normal methods.

_The `YamlCommentsExample` has been improved to reflect these changes.
More information will be available via the javadoc with the 1.8 release._