### PR TITLE
Corrected artifact group for maven & gradle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven you do not need to download the jar. Instead, add this re
 
 ```xml
 <dependency>
-    <groupId>me.carleslc.Simple-YAML</groupId>
+    <groupId>com.github.Carleslc.Simple-YAML</groupId>
     <artifactId>Simple-Yaml</artifactId>
     <version>1.8.4</version>
 </dependency>
@@ -63,7 +63,7 @@ If you are using Maven you do not need to download the jar. Instead, add this re
 
 ```xml
 <dependency>
-    <groupId>me.carleslc.Simple-YAML</groupId>
+    <groupId>com.github.Carleslc.Simple-YAML</groupId>
     <artifactId>Simple-Configuration</artifactId>
     <version>1.8.4</version>
 </dependency>
@@ -88,7 +88,7 @@ allprojects {
 
 ```gradle
 dependencies {
-  implementation 'me.carleslc.Simple-YAML:Simple-Yaml:1.8.4'
+  implementation 'com.github.Carleslc.Simple-YAML:Simple-Yaml:1.8.4'
 }
 ```
 
@@ -99,7 +99,7 @@ dependencies {
 
 ```gradle
 dependencies {
-  implementation 'me.carleslc.Simple-YAML:Simple-Configuration:1.8.4'
+  implementation 'com.github.Carleslc.Simple-YAML:Simple-Configuration:1.8.4'
 }
 ```
 


### PR DESCRIPTION
Since it's a jitpack artifact, its group should start with `com.github.Carleslc` instead of `me.carleslc`