### PR TITLE
Add missing get[Type] Functions to ConfigurationSection

### DIFF
--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/ConfigurationSection.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/ConfigurationSection.java
@@ -354,6 +354,46 @@ public interface ConfigurationSection {
     boolean isBoolean(String path);
 
     /**
+     * Gets the requested byte by path.
+     * <p>
+     * If the byte does not exist but a default value has been specified,
+     * this will return the default value. If the byte does not exist and
+     * no default value was specified, this will return 0.
+     *
+     * @param path Path of the byte to get.
+     * @return Requested byte.
+     */
+    byte getByte(String path);
+
+    /**
+     * Gets the requested byte by path, returning a default value if not
+     * found.
+     * <p>
+     * If the byte does not exist then the specified default value will
+     * returned regardless of if a default has been identified in the root
+     * {@link Configuration}.
+     *
+     * @param path Path of the byte to get.
+     * @param def  The default value to return if the path is not found or is
+     *             not a byte.
+     * @return Requested byte.
+     */
+    byte getByte(String path, byte def);
+
+    /**
+     * Checks if the specified path is a byte.
+     * <p>
+     * If the path exists but is not a byte, this will return false. If the
+     * path does not exist, this will return false. If the path does not exist
+     * but a default value has been specified, this will check if that default
+     * value is a byte and return appropriately.
+     *
+     * @param path Path of the byte to check.
+     * @return Whether or not the specified path is a byte.
+     */
+    boolean isByte(String path);
+
+    /**
      * Gets the requested double by path.
      * <p>
      * If the double does not exist but a default value has been specified,

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/ConfigurationSection.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/ConfigurationSection.java
@@ -473,6 +473,46 @@ public interface ConfigurationSection {
      */
     boolean isLong(String path);
 
+    /**
+     * Gets the requested short by path.
+     * <p>
+     * If the short does not exist but a default value has been specified, this
+     * will return the default value. If the short does not exist and no
+     * default value was specified, this will return 0.
+     *
+     * @param path Path of the short to get.
+     * @return Requested short.
+     */
+    short getShort(String path);
+
+    /**
+     * Gets the requested short by path, returning a default value if not
+     * found.
+     * <p>
+     * If the short does not exist then the specified default value will
+     * returned regardless of if a default has been identified in the root
+     * {@link Configuration}.
+     *
+     * @param path Path of the short to get.
+     * @param def  The default value to return if the path is not found or is
+     *             not a short.
+     * @return Requested short.
+     */
+    short getShort(String path, short def);
+
+    /**
+     * Checks if the specified path is a short.
+     * <p>
+     * If the path exists but is not a short, this will return false. If the
+     * path does not exist, this will return false. If the path does not exist
+     * but a default value has been specified, this will check if that default
+     * value is a short and return appropriately.
+     *
+     * @param path Path of the short to check.
+     * @return Whether or not the specified path is a short.
+     */
+    boolean isShort(String path);
+
     // Java
 
     /**

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/ConfigurationSection.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/ConfigurationSection.java
@@ -394,6 +394,46 @@ public interface ConfigurationSection {
     boolean isByte(String path);
 
     /**
+     * Gets the requested char by path.
+     * <p>
+     * If the char does not exist but a default value has been specified,
+     * this will return the default value. If the char does not exist and
+     * no default value was specified, this will return '\0'.
+     *
+     * @param path Path of the char to get.
+     * @return Requested char.
+     */
+    char getCharacter(String path);
+
+    /**
+     * Gets the requested char by path, returning a default value if not
+     * found.
+     * <p>
+     * If the char does not exist then the specified default value will
+     * returned regardless of if a default has been identified in the root
+     * {@link Configuration}.
+     *
+     * @param path Path of the char to get.
+     * @param def  The default value to return if the path is not found or is
+     *             not a char.
+     * @return Requested char.
+     */
+    char getCharacter(String path, char def);
+
+    /**
+     * Checks if the specified path is a char.
+     * <p>
+     * If the path exists but is not a char, this will return false. If the
+     * path does not exist, this will return false. If the path does not exist
+     * but a default value has been specified, this will check if that default
+     * value is a char and return appropriately.
+     *
+     * @param path Path of the char to check.
+     * @return Whether or not the specified path is a char.
+     */
+    boolean isCharacter(String path);
+
+    /**
      * Gets the requested double by path.
      * <p>
      * If the double does not exist but a default value has been specified,

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/ConfigurationSection.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/ConfigurationSection.java
@@ -434,6 +434,46 @@ public interface ConfigurationSection {
     boolean isDouble(String path);
 
     /**
+     * Gets the requested float by path.
+     * <p>
+     * If the float does not exist but a default value has been specified,
+     * this will return the default value. If the float does not exist and no
+     * default value was specified, this will return 0.
+     *
+     * @param path Path of the float to get.
+     * @return Requested float.
+     */
+    float getFloat(String path);
+
+    /**
+     * Gets the requested float by path, returning a default value if not
+     * found.
+     * <p>
+     * If the float does not exist then the specified default value will
+     * returned regardless of if a default has been identified in the root
+     * {@link Configuration}.
+     *
+     * @param path Path of the float to get.
+     * @param def  The default value to return if the path is not found or is
+     *             not a float.
+     * @return Requested float.
+     */
+    float getFloat(String path, float def);
+
+    /**
+     * Checks if the specified path is a float.
+     * <p>
+     * If the path exists but is not a float, this will return false. If the
+     * path does not exist, this will return false. If the path does not exist
+     * but a default value has been specified, this will check if that default
+     * value is a float and return appropriately.
+     *
+     * @param path Path of the float to check.
+     * @return Whether or not the specified path is a float.
+     */
+    boolean isFloat(String path);
+
+    /**
      * Gets the requested long by path.
      * <p>
      * If the long does not exist but a default value has been specified, this

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/MemorySection.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/MemorySection.java
@@ -642,6 +642,24 @@ public class MemorySection implements ConfigurationSection {
     }
 
     @Override
+    public byte getByte(final String path) {
+        final Object def = this.getDefault(path);
+        return this.getByte(path, def instanceof Number ? NumberConversions.toByte(def) : 0);
+    }
+
+    @Override
+    public byte getByte(final String path, final byte def) {
+        final Object val = this.get(path, def);
+        return val instanceof Number ? NumberConversions.toByte(val) : def;
+    }
+
+    @Override
+    public boolean isByte(final String path) {
+        final Object val = this.get(path);
+        return val instanceof Byte;
+    }
+
+    @Override
     public double getDouble(final String path) {
         final Object def = this.getDefault(path);
         return this.getDouble(path, def instanceof Number ? NumberConversions.toDouble(def) : 0);

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/MemorySection.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/MemorySection.java
@@ -1,6 +1,7 @@
 package org.simpleyaml.configuration;
 
 import org.simpleyaml.configuration.serialization.ConfigurationSerializable;
+import org.simpleyaml.utils.CharacterConversions;
 import org.simpleyaml.utils.NumberConversions;
 import org.simpleyaml.utils.StringUtils;
 import org.simpleyaml.utils.Validate;
@@ -657,6 +658,24 @@ public class MemorySection implements ConfigurationSection {
     public boolean isByte(final String path) {
         final Object val = this.get(path);
         return val instanceof Byte;
+    }
+
+    @Override
+    public char getCharacter(final String path) {
+        final Object def = this.getDefault(path);
+        return this.getCharacter(path, def instanceof Character ? (Character) def : '\0');
+    }
+
+    @Override
+    public char getCharacter(final String path, final char def) {
+        final Object val = this.get(path, def);
+        return CharacterConversions.canBeChar(val) ? CharacterConversions.toChar(val) : def;
+    }
+
+    @Override
+    public boolean isCharacter(final String path) {
+        final Object val = this.get(path);
+        return val instanceof Character;
     }
 
     @Override

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/MemorySection.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/MemorySection.java
@@ -678,6 +678,24 @@ public class MemorySection implements ConfigurationSection {
     }
 
     @Override
+    public float getFloat(final String path) {
+        final Object def = this.getDefault(path);
+        return this.getFloat(path, def instanceof Number ? NumberConversions.toFloat(def) : 0);
+    }
+
+    @Override
+    public float getFloat(final String path, final float def) {
+        final Object val = this.get(path, def);
+        return val instanceof Number ? NumberConversions.toFloat(val) : def;
+    }
+
+    @Override
+    public boolean isFloat(final String path) {
+        final Object val = this.get(path);
+        return val instanceof Float;
+    }
+
+    @Override
     public long getLong(final String path) {
         final Object def = this.getDefault(path);
         return this.getLong(path, def instanceof Number ? NumberConversions.toLong(def) : 0);

--- a/Simple-Configuration/src/main/java/org/simpleyaml/configuration/MemorySection.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/configuration/MemorySection.java
@@ -695,6 +695,24 @@ public class MemorySection implements ConfigurationSection {
         return val instanceof Long;
     }
 
+    @Override
+    public short getShort(final String path) {
+        final Object def = this.getDefault(path);
+        return this.getShort(path, def instanceof Number ? NumberConversions.toShort(def) : 0);
+    }
+
+    @Override
+    public short getShort(final String path, final short def) {
+        final Object val = this.get(path, def);
+        return val instanceof Number ? NumberConversions.toShort(val) : def;
+    }
+
+    @Override
+    public boolean isShort(final String path) {
+        final Object val = this.get(path);
+        return val instanceof Short;
+    }
+
     // Java
     @Override
     public List<?> getList(final String path) {

--- a/Simple-Configuration/src/main/java/org/simpleyaml/utils/CharacterConversions.java
+++ b/Simple-Configuration/src/main/java/org/simpleyaml/utils/CharacterConversions.java
@@ -1,0 +1,39 @@
+package org.simpleyaml.utils;
+
+public class CharacterConversions {
+    public static boolean canBeChar(final Object object) {
+        if (object instanceof Character) {
+            return true;
+        }
+
+        if (object instanceof String) {
+            final String str = (String) object;
+
+            if (str.length() == 1) {
+                return true;
+            }
+        }
+
+        return object instanceof Number;
+    }
+
+    public static char toChar(final Object object) {
+        if (object instanceof Character) {
+            return (Character) object;
+        }
+
+        if (object instanceof String) {
+            final String str = (String) object;
+
+            if (str.length() == 1) {
+                return str.charAt(0);
+            }
+        }
+
+        if (object instanceof Number) {
+            return (char) ((Number) object).intValue();
+        }
+
+        return '\0';
+    }
+}


### PR DESCRIPTION
I added the single value getters for `char`, `float`, `short` and `byte` which were only available if you had a list.